### PR TITLE
add litellm ui to docker compose

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -49,14 +49,25 @@ services:
       - .env
 
   litellm_proxy:
-    image: ghcr.io/berriai/litellm:main-v1.34.6
+    image: ghcr.io/berriai/litellm-database:main-latest
     restart: always
     env_file:
       - .env
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@litellm_proxy_db:5432/litellm
     volumes:
       - ./litellm_proxy_config.yaml:/app/config.yaml
+    ports:
+      - "4000:4000"
     command:
       ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
+
+  litellm_proxy_db:
+    image: postgres:16
+    environment:
+      - PORT=5432
+      - POSTGRES_DB=litellm
+      - POSTGRES_PASSWORD=postgres
 
   alignScore:
     image: idinsight/alignscore-base:latest

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -36,6 +36,7 @@ UI_USERNAME="admin"
 UI_PASSWORD="admin"
 # endpoint for the backend to call - must be set to the internal service name and port
 LITELLM_ENDPOINT="http://litellm_proxy:4000"
+LITELLM_MASTER_KEY="dummy-key"
 
 ### Variables for Langfuse integration
 # LANGFUSE_SECRET_KEY=sk-...


### PR DESCRIPTION
Reviewer:
Estimate:

---

## Ticket

Fixes: JIRA_TICKET_LINK

## Description

### Goal

I wanted to explore LiteLLM proxy server's UI. This branch allows you to set up UI via docker-compose (does not include AWS deployment).

### Changes

1. Modify docker-compose to use litellm proxy with external DB (postgres container)
2. Add new env var in template

### Future Tasks (optional)

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. Delete any lines that are not relevant

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
- [ ] I have added blogpost in Latest Updates
