### PR TITLE
Update all mention doc links with new URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thank you for being interested in contributing to AAQ.
 
 AAQ is an open source project started by data scientists at IDinsight and sponsored by Google.org and all are welcome to contribute to it. In fact, the success of the project depends on it.
 
-See our [contibuting docs](https://idinsight.github.io/aaq-core/develop/contributing/) for how to get started.
+See our [contibuting docs](https://docs.ask-a-question.com/develop/contributing/) for how to get started.
 
 ## Quick links
 
-- [Pull Requests Step-by-step guide](https://idinsight.github.io/aaq-core/develop/contributing/#pull-requests-guide)
-- [Setting up your development environment](https://idinsight.github.io/aaq-core/develop/setup)
+- [Pull Requests Step-by-step guide](https://docs.ask-a-question.com/develop/contributing/#pull-requests-guide)
+- [Setting up your development environment](https://docs.ask-a-question.com/develop/setup)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 <p align="center" style="text-align:center">
-<a href="https://idinsight.github.io/aaq-core/">Developer Docs</a> |
+<a href="https://docs.ask-a-question.com/">Developer Docs</a> |
 <a href="#features">Features</a> |
 <a href="#usage">Usage</a> |
 <a href="#architecture">Architecture</a> |
@@ -63,7 +63,7 @@ To get answers from your database of contents, you can use the `/search` endpoin
 - Search results: Finds the most similar content in the database using cosine distance between embeddings.
 - (Optionally) LLM generated response: Crafts a custom response using LLM chat using the most similar content.
 
-See [docs](https://idinsight.github.io/aaq-core/) or [API docs](https://app.ask-a-question.com/api/docs) for more details and other API endpoints.
+See [docs](https://docs.ask-a-question.com/) or [API docs](https://app.ask-a-question.com/api/docs) for more details and other API endpoints.
 
 ### :question: Simple content search
 
@@ -115,7 +115,7 @@ We use docker-compose to orchestrate containers with a reverse proxy that manage
 
 ## Documentation
 
-See [here](https://idinsight.github.io/aaq-core/) for full documentation.
+See [here](https://docs.ask-a-question.com/) for full documentation.
 
 ## Funders and Partners
 

--- a/admin_app/src/app/integrations/components/ChatManagerModalContents.tsx
+++ b/admin_app/src/app/integrations/components/ChatManagerModalContents.tsx
@@ -75,7 +75,7 @@ const TurnModalContent: React.FC = () => {
       >
         For now, please refer to our{" "}
         <Link
-          href="https://idinsight.github.io/aaq-core/integrations/chat_managers/turn.io/turn/"
+          href="https://docs.ask-a-question.com/integrations/chat_managers/turn.io/turn/"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -101,7 +101,7 @@ const GlificModalContent: React.FC = () => {
       >
         For now, please refer to our{" "}
         <Link
-          href="https://idinsight.github.io/aaq-core/integrations/chat_managers/glific/glific/"
+          href="https://docs.ask-a-question.com/integrations/chat_managers/glific/glific/"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/core_backend/app/__init__.py
+++ b/core_backend/app/__init__.py
@@ -27,7 +27,7 @@ page_description = """
 
 🔑 <a href="https://app.ask-a-question.com/integrations" target="_blank">Get your API
 key</a> |
-📖 <a href="https://idinsight.github.io/aaq-core" target="_blank">Docs</a> |
+📖 <a href="https://docs.ask-a-question.com" target="_blank">Docs</a> |
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="1em"
 style="vertical-align: bottom;"><path d="m0 0h24v24h-24z" fill="#fff" opacity="0"
 transform="matrix(-1 0 0 -1 24 24)"/><path d="m12 1a10.89 10.89 0 0 0 -11 10.77 10.79

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ To get answers from your database of contents, you can use the `/search` endpoin
 - Search results: Finds the most similar content in the database using cosine distance between embeddings.
 - (Optionally) LLM generated response: Crafts a custom response using LLM chat using the most similar content.
 
-You can also add your contents programatically using API endpoints. See [docs](https://idinsight.github.io/aaq-core/) or SwaggerUI at `https://<DOMAIN>/api/docs` or `https://<DOMAIN>/docs` for more details and other API endpoints.
+You can also add your contents programatically using API endpoints. See [docs](https://docs.ask-a-question.com/) or SwaggerUI at `https://<DOMAIN>/api/docs` or `https://<DOMAIN>/docs` for more details and other API endpoints.
 
 ### :question: Embeddings search
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "" # already part of the logo
 site_description: "Ask A Question Documentation"
-site_url: https://idinsight.github.io/aaq-core/
+site_url: https://ask-a-question.com//
 repo_url: https://github.com/IDinsight/ask-a-question
 copyright: "© 2024 IDinsight"
 extra:


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 5 mins

---

## Ticket

N/A


### Goal

Replace all places where we refer to our "docs links" from the old github.io URL to our new docs.asl-a-question.com. Also change one instance where I linked to our new landing page, when linking our "app website".


## How has this been tested?

Double checked all new URLs work by hand


## Checklist

Fill with `x` for completed. 

- [x ] My code follows the style guidelines of this project
- [ x] I have reviewed my own code to ensure good quality
- [ x] I have tested the functionality of my code to ensure it works as intended
- [ x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
