### PR TITLE
[AAQ-661] Deploy to prod on release

### DIFF
--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -15,15 +15,20 @@ on:
 
 jobs:
   set-env:
-    # This step outputs the deployment environment name.
-    # It is set to `production` if the workflow is triggered by a release or a push to
-    # `production` branch.
-    # It is set to `testing` if the workflow was triggered by a push to `main` branch
-    # or `testing` branch.
-    # Otherwise, set the environment to the branch name.
     runs-on: ubuntu-latest
     outputs:
-      env_name: ${{ (github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
+      env_name: ${{ steps.set-env.outputs.env_name }}
+    steps:
+      - name: Resolve deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ github.event_name }}" == "release" && "${{ github.event.action }}  == "released"]; then
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          fi
 
   DeployAdminAppToGCP:
     needs: [set-env]

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -9,6 +9,8 @@ on:
     paths:
       - "admin_app/**"
       - ".github/workflows/deploy_gcp_admin_app.yaml"
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:
@@ -19,11 +21,14 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+    # Set the environment to production if a release was created on the main branch. If
+    # this is main branch but not triggered by a release, set the environment to
+    # testing. Otherwise, set the environment to the branch name.
+    environment: gcp-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
-      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
+      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -27,7 +27,7 @@ jobs:
           elif [ "${{ github.ref_name }}" == "main" ]; then
             echo "env_name=testing" >> "$GITHUB_OUTPUT"
           else
-            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
   DeployAdminAppToGCP:

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -14,21 +14,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  set-env:
+    # This step outputs the deployment environment name.
+    # It is set to `production` if the workflow is triggered by a release or a push to
+    # `production` branch.
+    # It is set to `testing` if the workflow was triggered by a push to `main` branch
+    # or `testing` branch.
+    # Otherwise, set the environment to the branch name.
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ (github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
+
   DeployAdminAppToGCP:
+    needs: [set-env]
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: "read"
       id-token: "write"
 
-    # Set the environment to production if a release was created on the main branch. If
-    # this is main branch but not triggered by a release, set the environment to
-    # testing. Otherwise, set the environment to the branch name.
-    environment: gcp-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
+    environment: gcp-${{ needs.set-env.outputs.env_name }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
-      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ (github.ref == 'main' && github.event_name == 'release' && github.event.action == 'released' && 'production') || ((github.ref == 'main' && 'testing') || github.ref_name) }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
+      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
 
     steps:
       - uses: "actions/checkout@v4"
@@ -55,6 +65,7 @@ jobs:
           gcloud auth configure-docker ${{ secrets.DOCKER_REGISTRY_DOMAIN}}
 
       - name: Build and push admin_app image
+        if: ${{ needs.set-env.outputs.env_name == 'testing' }}
         working-directory: admin_app
         run: |
           docker build \
@@ -62,6 +73,17 @@ jobs:
             --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
             -t ${{ env.REPO }}/admin_app:latest \
             -t ${{ env.REPO }}/admin_app:${{ github.sha }} \
+            .
+          docker image push --all-tags ${{ env.REPO }}/admin_app
+
+      - name: Build and push admin_app image to production
+        if: ${{ needs.set-env.outputs.env_name == 'production' }}
+        working-directory: admin_app
+        run: |
+          docker build \
+            --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
+            --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
+            -t ${{ env.REPO }}/admin_app:${{ github.ref_name }}
             .
           docker image push --all-tags ${{ env.REPO }}/admin_app
 

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Resolve deployment environment name
         id: set-env
         run: |
-          if [ "${{ github.event_name }}" == "release" && "${{ github.event.action }}  == "released"]; then
+          if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
             echo "env_name=production" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" == "main" ]; then
             echo "env_name=testing" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Resolve deployment environment name
         id: set-env
-        run: |
+        run: | # fix first condition to production after test
           if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
-            echo "env_name=production" >> "$GITHUB_OUTPUT"
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" == "main" ]; then
             echo "env_name=testing" >> "$GITHUB_OUTPUT"
           else
@@ -69,20 +69,21 @@ jobs:
         run: |
           gcloud auth configure-docker ${{ secrets.DOCKER_REGISTRY_DOMAIN}}
 
-      - name: Build and push admin_app image
-        if: ${{ needs.set-env.outputs.env_name == 'testing' }}
-        working-directory: admin_app
-        run: |
-          docker build \
-            --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
-            --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
-            -t ${{ env.REPO }}/admin_app:latest \
-            -t ${{ env.REPO }}/admin_app:${{ github.sha }} \
-            .
-          docker image push --all-tags ${{ env.REPO }}/admin_app
+      # - name: Build and push admin_app image
+      #   if: ${{ needs.set-env.outputs.env_name == 'testing' }}
+      #   working-directory: admin_app
+      #   run: |
+      #     docker build \
+      #       --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
+      #       --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
+      #       -t ${{ env.REPO }}/admin_app:latest \
+      #       -t ${{ env.REPO }}/admin_app:${{ github.sha }} \
+      #       .
+      #     docker image push --all-tags ${{ env.REPO }}/admin_app
 
-      - name: Build and push admin_app image to production
-        if: ${{ needs.set-env.outputs.env_name == 'production' }}
+      # Fix the following to production after testing
+      - name: Build and push admin_app image to production (to be fixed)
+        if: ${{ needs.set-env.outputs.env_name == 'testing' }}
         working-directory: admin_app
         run: |
           docker build \

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Resolve deployment environment name
         id: set-env
-        run: | # fix first condition to production after test
+        run: |
           if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
-            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" == "main" ]; then
             echo "env_name=testing" >> "$GITHUB_OUTPUT"
           else
@@ -44,8 +44,7 @@ jobs:
     env:
       RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
       REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
-      TAG: ${{ (needs.set-env.outputs.env_name == 'testing' && github.ref_name) || github.sha }}
-    # Update TAG condition to production
+      TAG: ${{ (needs.set-env.outputs.env_name == 'production' && github.ref_name) || github.sha }}
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -44,6 +44,7 @@ jobs:
     env:
       RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
       REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
+      TAG: ${{ (needs.set-env.outputs.env_name == 'production' && github.ref_name) || github.sha }}
 
     steps:
       - uses: "actions/checkout@v4"
@@ -69,27 +70,14 @@ jobs:
         run: |
           gcloud auth configure-docker ${{ secrets.DOCKER_REGISTRY_DOMAIN}}
 
-      # - name: Build and push admin_app image
-      #   if: ${{ needs.set-env.outputs.env_name == 'testing' }}
-      #   working-directory: admin_app
-      #   run: |
-      #     docker build \
-      #       --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
-      #       --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
-      #       -t ${{ env.REPO }}/admin_app:latest \
-      #       -t ${{ env.REPO }}/admin_app:${{ github.sha }} \
-      #       .
-      #     docker image push --all-tags ${{ env.REPO }}/admin_app
-
-      # Fix the following to production after testing
-      - name: Build and push admin_app image to production (to be fixed)
-        if: ${{ needs.set-env.outputs.env_name == 'testing' }}
+      - name: Build and push admin_app image
         working-directory: admin_app
         run: |
           docker build \
             --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
             --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
-            -t ${{ env.REPO }}/admin_app:${{ github.ref_name }} \
+            -t ${{ env.REPO }}/admin_app:latest \
+            -t ${{ env.REPO }}/admin_app:${{ env.TAG }} \
             .
           docker image push --all-tags ${{ env.REPO }}/admin_app
 

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -44,7 +44,8 @@ jobs:
     env:
       RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
       REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
-      TAG: ${{ (needs.set-env.outputs.env_name == 'production' && github.ref_name) || github.sha }}
+      TAG: ${{ (needs.set-env.outputs.env_name == 'testing' && github.ref_name) || github.sha }}
+    # Update TAG condition to production
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -89,7 +89,7 @@ jobs:
           docker build \
             --build-arg NEXT_PUBLIC_BACKEND_URL="https://${{ steps.secrets.outputs.domain }}/api" \
             --build-arg NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="${{ steps.secrets.outputs.google_login_client_id }}" \
-            -t ${{ env.REPO }}/admin_app:${{ github.ref_name }}
+            -t ${{ env.REPO }}/admin_app:${{ github.ref_name }} \
             .
           docker image push --all-tags ${{ env.REPO }}/admin_app
 

--- a/.github/workflows/deploy_gcp_caddy.yaml
+++ b/.github/workflows/deploy_gcp_caddy.yaml
@@ -9,21 +9,40 @@ on:
     paths:
       - "deployment/docker-compose/caddy/**"
       - ".github/workflows/deploy_gcp_caddy.yaml"
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+    steps:
+      - name: Resolve deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
   DeployCaddyToGCP:
+    needs: [set-env]
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: "read"
       id-token: "write"
 
-    # TODO: replace improve-gcp-deploy with main
-    environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+    environment: gcp-${{ needs.set-env.outputs.env_name }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/deploy_gcp_core_backend.yaml
+++ b/.github/workflows/deploy_gcp_core_backend.yaml
@@ -9,22 +9,42 @@ on:
     paths:
       - "core_backend/**"
       - ".github/workflows/deploy_gcp_core_backend.yaml"
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+    steps:
+      - name: Resolve deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
   DeployCoreBackendToGCP:
+    needs: [set-env]
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: "read"
       id-token: "write"
 
-    # TODO: replace improve-gcp-deploy with main
-    environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+    environment: gcp-${{ needs.set-env.outputs.env_name }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
-      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
+      REPO: ${{ secrets.DOCKER_REGISTRY_DOMAIN }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
+      TAG: ${{ (needs.set-env.outputs.env_name == 'production' && github.ref_name) || github.sha }}
 
     steps:
       - uses: "actions/checkout@v4"
@@ -62,7 +82,7 @@ jobs:
         run: |
           docker build \
             -t ${{ env.REPO }}/core_backend:latest \
-            -t ${{ env.REPO }}/core_backend:${{ github.sha }} \
+            -t ${{ env.REPO }}/core_backend:${{ env.TAG }} \
             .
           docker image push --all-tags ${{ env.REPO }}/core_backend
 

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -9,21 +9,40 @@ on:
     paths:
       - "deployment/docker-compose/litellm_proxy/**"
       - ".github/workflows/deploy_gcp_litellm_proxy.yaml"
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+    steps:
+      - name: Resolve deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
   DeployLiteLLMProxyToGCP:
+    needs: [set-env]
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: "read"
       id-token: "write"
 
-    # TODO: replace improve-gcp-deploy with main
-    environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+    environment: gcp-${{ needs.set-env.outputs.env_name }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/deploy_gcp_redis.yaml
+++ b/.github/workflows/deploy_gcp_redis.yaml
@@ -8,21 +8,40 @@ on:
       - production
     paths:
       - ".github/workflows/deploy_gcp_redis.yaml"
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+    steps:
+      - name: Resolve deployment environment name
+        id: set-env
+        run: |
+          if [ "${{ github.event_name }}" == "release" ] && [ "${{ github.event.action }}" == "released" ]; then
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            echo "env_name=testing" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
   DeployRedisToGCP:
+    needs: [set-env]
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: "read"
       id-token: "write"
 
-    # TODO: replace improve-gcp-deploy with main
-    environment: gcp-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+    environment: gcp-${{ needs.set-env.outputs.env_name }}
 
     env:
-      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ (github.ref_name == 'main' && 'testing') || github.ref_name }}
+      RESOURCE_PREFIX: ${{ secrets.PROJECT_NAME }}-${{ needs.set-env.outputs.env_name }}
 
     steps:
       - uses: "actions/checkout@v4"
@@ -52,7 +71,7 @@ jobs:
               --name redis \
               -p 6379:6379 \
               redis:6.0-alpine
-            docker system prune --volumes -f
+            docker system prune --volumes -f || true
 
       - name: Show deployment command output
         run: |-

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -648,9 +648,5 @@
       }
     ]
   },
-<<<<<<< HEAD
   "generated_at": "2024-08-06T06:34:25Z"
-=======
-  "generated_at": "2024-07-26T14:40:47Z"
->>>>>>> 273b6a4b (apply same changes to other cicd scripts)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,7 +142,7 @@
         "filename": ".github/workflows/deploy_gcp_caddy.yaml",
         "hashed_secret": "8fb442254a9f97b52d4c560877a40cf61e9884e0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 62
       }
     ],
     ".github/workflows/deploy_gcp_core_backend.yaml": [
@@ -151,7 +151,7 @@
         "filename": ".github/workflows/deploy_gcp_core_backend.yaml",
         "hashed_secret": "14a9a30abdb4f24769083489080470ca78f002f6",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 64
       }
     ],
     ".github/workflows/deploy_gcp_litellm_proxy.yaml": [
@@ -160,7 +160,7 @@
         "filename": ".github/workflows/deploy_gcp_litellm_proxy.yaml",
         "hashed_secret": "0055da8a34a8538e3164350241dd2daf9f3994fc",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 62
       }
     ],
     ".github/workflows/retrieval-validation.yaml": [
@@ -648,5 +648,9 @@
       }
     ]
   },
+<<<<<<< HEAD
   "generated_at": "2024-08-06T06:34:25Z"
+=======
+  "generated_at": "2024-07-26T14:40:47Z"
+>>>>>>> 273b6a4b (apply same changes to other cicd scripts)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,11 +133,7 @@
         "filename": ".github/workflows/deploy_gcp_admin_app.yaml",
         "hashed_secret": "a9940a62000a2eb35500c88932f05e62c364896e",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 49
-=======
-        "line_number": 64
->>>>>>> 59b03228 (add step to resolve deployment name inside job)
+        "line_number": 65
       }
     ],
     ".github/workflows/deploy_gcp_caddy.yaml": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/deploy_gcp_admin_app.yaml",
         "hashed_secret": "a9940a62000a2eb35500c88932f05e62c364896e",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 65
       }
     ],
     ".github/workflows/deploy_gcp_caddy.yaml": [
@@ -648,9 +648,5 @@
       }
     ]
   },
-<<<<<<< HEAD
   "generated_at": "2024-08-06T06:34:25Z"
-=======
-  "generated_at": "2024-07-26T14:28:14Z"
->>>>>>> cc95dbd5 (temporarily use ref_name as tag for testing)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/deploy_gcp_admin_app.yaml",
         "hashed_secret": "a9940a62000a2eb35500c88932f05e62c364896e",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 66
       }
     ],
     ".github/workflows/deploy_gcp_caddy.yaml": [
@@ -648,5 +648,9 @@
       }
     ]
   },
+<<<<<<< HEAD
   "generated_at": "2024-08-06T06:34:25Z"
+=======
+  "generated_at": "2024-07-26T14:28:14Z"
+>>>>>>> cc95dbd5 (temporarily use ref_name as tag for testing)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,11 @@
         "filename": ".github/workflows/deploy_gcp_admin_app.yaml",
         "hashed_secret": "a9940a62000a2eb35500c88932f05e62c364896e",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 49
+=======
+        "line_number": 64
+>>>>>>> 59b03228 (add step to resolve deployment name inside job)
       }
     ],
     ".github/workflows/deploy_gcp_caddy.yaml": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/deploy_gcp_admin_app.yaml",
         "hashed_secret": "a9940a62000a2eb35500c88932f05e62c364896e",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 49
       }
     ],
     ".github/workflows/deploy_gcp_caddy.yaml": [


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 30 minutes

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-661

## Description

### Goal

Modify CI/CD scripts so that when a release is published, it is deployed to production.

### Changes

1. Add trigger event: when a release is **released** ("A release was published, or a pre-release was changed to a release.", see different release actions [here](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release))
2. Add a job to parse the deployment environment
    - If the trigger condition was "event=release" & "action=released", set it to production
    - If the trigger condition is a push to main, set it to testing
3. Use version tag as image tag for production images

## How has this been tested?

1. In change no. 2., I set the environment to be `testing` for release.
    ```shell
    [-] echo "env_name=production" >> "$GITHUB_OUTPUT"
    [+] echo "env_name=testing" >> "$GITHUB_OUTPUT"
    ```
3. In Github, I created a release at this branch (relase-prod-action) with a new tag (create a new tag -> v0.0.0-test) and published the release
4. Check that action deploys the new image to testing environment (also check in Artifact Registry that new image was pushed, and on instance that the new image was run)

Then I reverted back 1 and 2.

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have updated affected documentation
- [x] I have updated the CI/CD scripts in `.github/workflows/`
