### PR TITLE
[Hotfix] Ensure commands ends successfully despite concurrent pruning issue

### DIFF
--- a/.github/workflows/deploy_gcp_admin_app.yaml
+++ b/.github/workflows/deploy_gcp_admin_app.yaml
@@ -82,7 +82,7 @@ jobs:
               --network aaq-network \
               --name admin_app \
               ${{ env.REPO }}/admin_app:latest
-            docker system prune -f;
+            docker system prune -f || true
 
       - name: Show deployment command output
         run: |-

--- a/.github/workflows/deploy_gcp_caddy.yaml
+++ b/.github/workflows/deploy_gcp_caddy.yaml
@@ -73,7 +73,7 @@ jobs:
                 --network aaq-network \
                 --name caddy \
                 caddy:2.7.6
-            docker system prune --volumes -f;
+            docker system prune --volumes -f || true
 
       - name: Show deployment command output
         run: |-

--- a/.github/workflows/deploy_gcp_core_backend.yaml
+++ b/.github/workflows/deploy_gcp_core_backend.yaml
@@ -102,7 +102,7 @@ jobs:
               -e LANGFUSE_PUBLIC_KEY="${{ steps.secrets.outputs.langfuse-public-key }}" \
               -e BACKEND_ROOT_PATH=/api \
               ${{ env.REPO }}/core_backend:latest
-            docker system prune -f;
+            docker system prune -f || true
 
       - name: Show deployment command output
         run: |-

--- a/.github/workflows/deploy_gcp_litellm_proxy.yaml
+++ b/.github/workflows/deploy_gcp_litellm_proxy.yaml
@@ -79,7 +79,7 @@ jobs:
               --network aaq-network \
               --name litellm_proxy \
               ghcr.io/berriai/litellm:main-v1.40.10 --config /app/config.yaml --num_workers 4
-            docker system prune -f;
+            docker system prune -f || true
 
       - name: Show deployment command output
         run: |-


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 5 mins

---

## Description

The `|| true` should mean the final line defaults to passing successfully even if there is a clash and we try to send two `docker prune -f` commands concurrently. 

### Goal

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [ x] My code follows the style guidelines of this project
- [ x] I have reviewed my own code to ensure good quality
- [ x] I have tested the functionality of my code to ensure it works as intended
- [ x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
