### PR TITLE
Fixing deadlock issue

### DIFF
--- a/core_backend/app/contents/models.py
+++ b/core_backend/app/contents/models.py
@@ -195,7 +195,7 @@ async def increment_query_count(
         if content_db:
             content_db.query_count = content_db.query_count + 1
             await asession.merge(content_db)
-    await asession.commit()
+            await asession.commit()
 
 
 async def delete_content_from_db(


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: 15mins

---

## Ticket

Fixes: HOTFIX

## Description

### Goal
Currenrtly, everytime we call the `/search` endpoint, we update the number of time each retrieved content is called. Issue Concurrent calls to the `/search ` can results in the same content trying to be updated multple times which creates a deadlock. This quick PR fixes
### Changes
- Update of  `increment_query_count` function
### Future Tasks (optional)

## How has this been tested?
- Tried to recreate the deadlock and made sure it didn't happen

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
