### PR TITLE
update docs to add link to redoc

### DIFF
--- a/core_backend/app/__init__.py
+++ b/core_backend/app/__init__.py
@@ -28,6 +28,8 @@ page_description = """
 🔑 <a href="https://app.ask-a-question.com/integrations" target="_blank">Get your API
 key</a> |
 📖 <a href="https://docs.ask-a-question.com" target="_blank">Docs</a> |
+☁️ <a href="https://app.ask-a-question.com/api/redoc" target="_blank">APIs</a> |
+🧪 <a href="https://app.ask-a-question.com/api/docs" target="_blank">Test APIs</a> |
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="1em"
 style="vertical-align: bottom;"><path d="m0 0h24v24h-24z" fill="#fff" opacity="0"
 transform="matrix(-1 0 0 -1 24 24)"/><path d="m12 1a10.89 10.89 0 0 0 -11 10.77 10.79

--- a/docs/components/qa-service/index.md
+++ b/docs/components/qa-service/index.md
@@ -48,13 +48,10 @@ as text, or as both.
 <img src="./swagger-ui-screenshot.png" alt="Screenshot of Swagger UI" style="border: 1px solid  lightgray;">
 
 If you have the [application running](../../deployment/quick-setup.md), you can access
-the SwaggerUI at
+the SwaggerUI at `https://[DOMAIN]/api/docs` and Redoc at `https://[DOMAIN]/api/redoc`
 
-    https://[DOMAIN]/api/docs
-
-or if you are using the [dev](../../develop/setup.md) setup:
-
-    http://localhost:8000/docs
+or if you are using the [dev](../../develop/setup.md) setup,
+`http://localhost:8000/docs` and `http://localhost:8000/redoc`.
 
 ## Upcoming
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ To get answers from your database of contents, you can use the `/search` endpoin
 - Search results: Finds the most similar content in the database using cosine distance between embeddings.
 - (Optionally) LLM generated response: Crafts a custom response using LLM chat using the most similar content.
 
-You can also add your contents programatically using API endpoints. See [docs](https://docs.ask-a-question.com/) or SwaggerUI at `https://<DOMAIN>/api/docs` or `https://<DOMAIN>/docs` for more details and other API endpoints.
+You can also add your contents programatically using API endpoints. See our [API docs](https://app.ask-a-question.com/api/redoc) for more details and other API endpoints.
 
 ### :question: Embeddings search
 
@@ -44,14 +44,14 @@ curl -X 'POST' \
 
 ## Admin app
 
-You can access the admin console at
+You can access the admin app of AAQ's cloud version [here](https://app.ask-a-question.com). You can
+also [self-host your own AAQ admin app](http://localhost:8080/deployment/quick-setup/).
 
-```
-https://[DOMAIN]/
-```
-
-On the [Admin app]("./content/admin-app.md"), you can:
+On the admin app, you can:
 
 - :books: Manage content for more details
 - :test_tube: Use the playground to test the Question-Answering service
 - :bar_chart: View dashboards
+
+See more detailed documentation of the admin app
+[here](http://localhost:8080/components/admin-app/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
   - Contact us:
       - Team: contact_us.md
 
-  - API docs ↗︎: https://app.ask-a-question.com/api/docs
+  - API docs ↗︎: https://app.ask-a-question.com/api/redoc
 
 # Themes and extensions
 theme:


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 10 mins

---

## Ticket

Fixes: None

## Description

### Goal

Link to redoc page for API docs, unless the guide is for testing the APIs. (Swagger UI allows for testing APIs, redoc doesn't)

### Changes

1. Add link to deployed docs on OpenAPI page description
2. Switch top-level "API docs" link to redoc page
3. Added/switched to redoc links in docs where appropriate

### Future Tasks

Remove Swagger UI captures in docs website. ([ticket](https://idinsight.atlassian.net/browse/AAQ-720))

## How has this been tested?

1. Run  `python core_backend/main.py`, check `HTTP://localhost:8000/redoc` and `/docs`.
2. Run `mkdocs serve -a localhost:8080` and check docs

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated affected documentation
