### PR TITLE
Fix setup-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ fresh-env :
 	fi
 
 # Dev requirements
-setup-dev: setup-db add-users-to-db setup-llm-proxy
-teardown-dev: teardown-db teardown-llm-proxy
+setup-dev: setup-db setup-redis add-users-to-db setup-llm-proxy
+teardown-dev: teardown-db teardown-redis teardown-llm-proxy
 
 ## Helper targets
 
@@ -50,6 +50,9 @@ setup-db:
      -d pgvector/pgvector:pg16
 	cd core_backend && \
 	python -m alembic upgrade head
+teardown-db:
+	@docker stop postgres-local
+	@docker rm postgres-local
 
 setup-redis:
 	-@docker stop redis-local
@@ -63,9 +66,7 @@ setup-redis:
 make teardown-redis:
 	@docker stop redis-local
 	@docker rm redis-local
-teardown-db:
-	@docker stop postgres-local
-	@docker rm postgres-local
+
 
 # Dev LiteLLM Proxy server
 setup-llm-proxy:


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 10mins

---

## Ticket

Fixes: HOTFIX

## Description

### Goal
 The goal of this PR is to fix an error where `setup-dev` doesn't work because `setup-redis` wasn't included
### Changes
 Added `setup-redis` to the `setup-dev` make command

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
