### PR TITLE
[AAQ-747] Bug fix: use content title in alignscore context

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -370,7 +370,7 @@
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "42553e798bc193bcf25368b5e53ec7cd771483a7",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 45
       },
       {
         "type": "Secret Keyword",
@@ -648,5 +648,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-05T13:04:30Z"
+  "generated_at": "2024-08-06T06:34:25Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -370,7 +370,7 @@
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "42553e798bc193bcf25368b5e53ec7cd771483a7",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
@@ -448,14 +448,14 @@
         "filename": "core_backend/tests/api/test_question_answer.py",
         "hashed_secret": "1d2be5ef28a76e2207456e7eceabe1219305e43d",
         "is_verified": false,
-        "line_number": 279
+        "line_number": 282
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/test_question_answer.py",
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_verified": false,
-        "line_number": 525
+        "line_number": 528
       }
     ],
     "core_backend/tests/api/test_user_tools.py": [
@@ -648,5 +648,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-03T12:58:28Z"
+  "generated_at": "2024-08-05T13:04:30Z"
 }

--- a/core_backend/app/question_answer/utils.py
+++ b/core_backend/app/question_answer/utils.py
@@ -10,9 +10,9 @@ def get_context_string_from_search_results(
     Get the context string from the retrieved content
     """
     context_list = []
-    for i, result in search_results.items():
+    for key, result in search_results.items():
         if not isinstance(result, QuerySearchResult):
             result = QuerySearchResult(**result)
-        context_list.append(f"{int(i)+1}. {result.title}\n{result.text}")
+        context_list.append(f"{key}. {result.title}\n{result.text}")
     context_string = "\n\n".join(context_list)
     return context_string

--- a/core_backend/app/question_answer/utils.py
+++ b/core_backend/app/question_answer/utils.py
@@ -3,7 +3,7 @@ from typing import Dict
 from .schemas import QuerySearchResult
 
 
-def get_context_string_from_retrieved_contents(
+def get_context_string_from_search_results(
     search_results: Dict[int, QuerySearchResult]
 ) -> str:
     """

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -83,7 +83,7 @@ async def asession(
 
 
 @pytest.fixture(scope="session", autouse=True)
-def admin_user(client: TestClient, db_session: Session) -> None:
+def admin_user(client: TestClient, db_session: Session) -> Generator:
     admin_user = UserDB(
         username=TEST_ADMIN_USERNAME,
         hashed_password=get_password_salted_hash(TEST_ADMIN_PASSWORD),
@@ -100,7 +100,7 @@ def admin_user(client: TestClient, db_session: Session) -> None:
 
 
 @pytest.fixture(scope="session")
-def user1(client: TestClient, db_session: Session) -> None:
+def user1(client: TestClient, db_session: Session) -> Generator:
     stmt = select(UserDB).where(UserDB.username == TEST_USERNAME)
     result = db_session.execute(stmt)
     user = result.scalar_one()
@@ -108,7 +108,7 @@ def user1(client: TestClient, db_session: Session) -> None:
 
 
 @pytest.fixture(scope="session")
-def user2(client: TestClient, db_session: Session) -> None:
+def user2(client: TestClient, db_session: Session) -> Generator:
     stmt = select(UserDB).where(UserDB.username == TEST_USERNAME_2)
     result = db_session.execute(stmt)
     user = result.scalar_one()
@@ -461,7 +461,7 @@ def fullaccess_token_user2() -> str:
 
 
 @pytest.fixture(scope="session")
-def api_key_user1(client, fullaccess_token: str) -> str:
+def api_key_user1(client: TestClient, fullaccess_token: str) -> str:
     """
     Returns a token with full access
     """
@@ -473,7 +473,7 @@ def api_key_user1(client, fullaccess_token: str) -> str:
 
 
 @pytest.fixture(scope="session")
-def api_key_user2(client, fullaccess_token_user2: str) -> str:
+def api_key_user2(client: TestClient, fullaccess_token_user2: str) -> str:
     """
     Returns a token with full access
     """


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: 10 minutes

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-747

## Description

### Goal

Include content title in context

### Changes

1. Uses existing context string generator
2. Removes _build_evidence

### Future Tasks (optional)

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [x] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
