### PR TITLE
[AAQ-729] Add mkdocs versioning

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,5 +33,5 @@ jobs:
           mike deploy \
             --ignore-remote-status \
             --update-aliases ${{ github.ref_name }} latest
+          mike set-default latest
           git push --force origin gh-pages
-          mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,4 +37,4 @@ jobs:
           echo "docs.ask-a-question.com" >> CNAME
           git add CNAME
           git commit -m "Add CNAME"
-          mkdocs gh-deploy --force --ignore-version
+          git push --force origin gh-page

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,9 @@
 name: Deploy Docs
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
+
 permissions:
   contents: write
 jobs:
@@ -25,5 +25,8 @@ jobs:
           pymdown-extensions==10.3 \
           mkdocs-glightbox==0.3.4 \
           mkdocs-material-extensions==1.3.1 \
-          mkdocs-open-in-new-tab==1.0.3
-      - run: mkdocs gh-deploy --force
+          mkdocs-open-in-new-tab==1.0.3 \
+          mike==2.1.2
+      - run: |
+          mike set-default --push latest
+          mike deploy --push --update-aliases ${{ github.ref_name }} latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,10 +33,8 @@ jobs:
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
           mike deploy \
-            --ignore-remote-status \
+            --push \
             --update-aliases ${{ github.ref_name }} latest
-          mike set-default latest
-          git push --force origin gh-pages
       - name: Add CNAME
         run: |
           git fetch origin

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,14 +28,16 @@ jobs:
           mkdocs-material-extensions==1.3.1 \
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
+
       - name: Build and push docs version
-        run: |
+        run: | # TODO: Change v0.1.1-test to github.ref_name
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
           git fetch origin gh-pages
           mike deploy \
             --push \
-            --update-aliases ${{ github.ref_name }} latest
+            --update-aliases v0.1.1-test latest
+
       - name: Add CNAME
         run: |
           git fetch origin

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,5 +30,8 @@ jobs:
       - run: |
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
-          mike deploy --ignore-remote-status --push --update-aliases ${{ github.ref_name }} latest
+          mike deploy \
+            --ignore-remote-status \
+            --update-aliases ${{ github.ref_name }} latest
+          git push --force origin gh-pages
           mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
@@ -34,4 +34,7 @@ jobs:
             --ignore-remote-status \
             --update-aliases ${{ github.ref_name }} latest
           mike set-default latest
-          git push --force origin gh-pages
+          echo "docs.ask-a-question.com" >> CNAME
+          git add CNAME
+          git commit -m "Add CNAME"
+          mkdocs gh-deploy --force --ignore-version

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,5 +30,5 @@ jobs:
       - run: | # TODO: switch v0.1.0 to github.ref_name
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
-          mike deploy --push --update-aliases v0.1.0 latest
+          mike deploy --push --update-aliases v0.1.0 latest --ignore-remote-status
           mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,5 +28,7 @@ jobs:
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
       - run: |
+          git config user.name github-actions-runner
+          git config user.email dsem@idinsight.org
           mike deploy --push --update-aliases ${{ github.ref_name }} latest
           mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,23 +21,27 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material==9.5.3 \
+      - name: Install dependencies
+        run: pip install mkdocs-material==9.5.3 \
           pymdown-extensions==10.3 \
           mkdocs-glightbox==0.3.4 \
           mkdocs-material-extensions==1.3.1 \
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
-      - run: |
+      - name: Build and push docs version
+        run: |
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
           mike deploy \
             --ignore-remote-status \
             --update-aliases ${{ github.ref_name }} latest
           mike set-default latest
-          git push --force origin gh-page
+          git push --force origin gh-pages
+      - name: Add CNAME
+        run: |
           git fetch origin
-          git switch gh-page
+          git switch gh-pages
           echo "docs.ask-a-question.com" >> CNAME
           git add CNAME
           git commit -m "Add CNAME"
-          git push origin gh-page
+          git push origin gh-pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,6 +32,7 @@ jobs:
         run: |
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
+          git fetch origin gh-pages
           mike deploy \
             --push \
             --update-aliases ${{ github.ref_name }} latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,8 +27,8 @@ jobs:
           mkdocs-material-extensions==1.3.1 \
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
-      - run: |
+      - run: | # TODO: switch v0.1.0 to github.ref_name
           git config user.name github-actions-runner
-          git config user.email dsem@idinsight.org
-          mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          git config user.email aaq@idinsight.org
+          mike deploy --push --update-aliases v0.1.0 latest
           mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,10 @@ jobs:
             --ignore-remote-status \
             --update-aliases ${{ github.ref_name }} latest
           mike set-default latest
+          git push --force origin gh-page
+          git fetch origin
+          git switch gh-page
           echo "docs.ask-a-question.com" >> CNAME
           git add CNAME
           git commit -m "Add CNAME"
-          git push --force origin gh-page
+          git push origin gh-page

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,8 +27,8 @@ jobs:
           mkdocs-material-extensions==1.3.1 \
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
-      - run: | # TODO: switch v0.1.0 to github.ref_name
+      - run: |
           git config user.name github-actions-runner
           git config user.email aaq@idinsight.org
-          mike deploy --push --update-aliases v0.1.0 latest --ignore-remote-status
+          mike deploy --ignore-remote-status --push --update-aliases ${{ github.ref_name }} latest
           mike set-default --push latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,5 +28,5 @@ jobs:
           mkdocs-open-in-new-tab==1.0.3 \
           mike==2.1.2
       - run: |
-          mike set-default --push latest
           mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ extra:
     - icon: material/shield-lock
       link: https://www.idinsight.org/about/privacy-policy/
       name: Privacy Policy
+  version:
+    provider: mike
+    alias: true
 
 nav:
   - Home:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "" # already part of the logo
 site_description: "Ask A Question Documentation"
-site_url: https://ask-a-question.com//
+site_url: https://docs.ask-a-question.com/
 repo_url: https://github.com/IDinsight/ask-a-question
 copyright: "© 2024 IDinsight"
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ extra:
   version:
     provider: mike
     alias: true
+    default: latest
 
 nav:
   - Home:


### PR DESCRIPTION
Reviewer: @markbotterill
Estimate: 30min

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-729

## Description

### Goal

Add versioning to mkdocs.

### Changes

1. Add `mike` versioning as per mkdocs' [documentation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#publishing-a-new-version)
2. Update docs github actions so that we only publish docs on release
3. Update docs actions to
    1. fetch existing `gh_pages` branch
    2. run `mike` to add new version and push the changes
    3. Add and commit a `CNAME` file manually which should contain the custom domain. This is because `mike` does not handle non-versioned files (see their [instructions](https://github.com/jimporter/mike?tab=readme-ov-file#cname-and-other-special-files)
4. Update actions to versions that use Node 20

### Future Tasks (optional)

## How has this been tested?

1. I created a fake version (v0.1.1-test) instead of using `${{ github.ref_name }}` in the docs.yaml. Pushed this.
2. Went to Github Actions - Deploy Docs -> workflow dispatch at this branch AAQ-729-doc-version
3. Check that a new version has been added to docs.ask-a-question.com
4. Check that older versions are still there

## To-do before merge (optional)

1. Git fetch origin gh-pages
2. git swith gh-pages
3. Remove v0.1.1-test version of docs
4. update symlink of latest to point to actual latest release tag:
    ```
    ln -sfn v0.1.0 latest
    ```

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
