### PR TITLE
HOTFIX: Clarify port forwarding and move add_dummy_data_to_db.py script into core_backend.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -414,7 +414,7 @@
         "filename": "core_backend/tests/api/test.env",
         "hashed_secret": "ca54df24e0b10f896f9958b2ec830058b15e7de2",
         "is_verified": false,
-        "line_number": 2
+        "line_number": 5
       }
     ],
     "core_backend/tests/api/test_dashboard.py": [

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -32,13 +32,14 @@ setup-test-db:
 	@set -a && source ./tests/api/test.env && set +a && \
 	python -m alembic upgrade head
 
+# Use port 6381 since port 6379 is used for dev and 6380 for docker-compose
 setup-redis-test:
 	-@docker stop redis-test
 	-@docker rm redis-test
 	@docker system prune -f
 	@sleep 2
 	@docker run --name redis-test \
-     -p 6397:6379 \
+	-p 6381:6379 \
      -d redis:6.0-alpine
 
 teardown-redis-test:
@@ -50,6 +51,7 @@ teardown-test-db:
 	@docker rm testdb
 
 # alignscore containers (if it is needed)
+# Use port 5002 since port 5001 is used for dev
 setup-alignscore-container:
 	-@docker stop testalignscore
 	-@docker rm testalignscore

--- a/core_backend/add_dummy_data_to_db.py
+++ b/core_backend/add_dummy_data_to_db.py
@@ -1,6 +1,6 @@
 """This script is useful if you want to test the dashboard with dummy data. Navigate to
-the root directory of the project and run the following command:
-    > python scripts/add_dummy_data_to_db.py
+the core_backend directory of the project and run the following command:
+    > python add_dummy_data_to_db.py
 """
 
 import os
@@ -23,22 +23,22 @@ if __name__ == "__main__":
         sys.path.append(PACKAGE_PATH)
 
 
-from core_backend.app.contents.config import PGVECTOR_VECTOR_SIZE
-from core_backend.app.contents.models import ContentDB
-from core_backend.app.database import get_session
-from core_backend.app.question_answer.models import (
+from app.contents.config import PGVECTOR_VECTOR_SIZE
+from app.contents.models import ContentDB
+from app.database import get_session
+from app.question_answer.models import (
     ContentFeedbackDB,
     QueryDB,
     ResponseFeedbackDB,
 )
-from core_backend.app.urgency_detection.models import UrgencyQueryDB, UrgencyResponseDB
+from app.urgency_detection.models import UrgencyQueryDB, UrgencyResponseDB
 
 # admin user (first user is admin)
 USER1_USERNAME = os.environ.get("USER1_USERNAME", "admin")
 USER1_PASSWORD = os.environ.get("USER1_PASSWORD", "fullaccess")
 _USER_ID = 1
 
-N_DATAPOINTS = 10
+N_DATAPOINTS = 100
 URGENCY_RATE = 0.1
 NEGATIVE_FEEDBACK_RATE = 0.1
 
@@ -140,7 +140,7 @@ def create_urgency_record(dt: datetime, is_urgent: bool, session: Session) -> No
         user_id=_USER_ID,
         message_text="test message",
         message_datetime_utc=dt,
-        feedback_secret_key="abc123",
+        feedback_secret_key="abc123",  # pragma: allowlist secret
     )
     session.add(urgency_db)
     session.commit()

--- a/core_backend/tests/api/test.env
+++ b/core_backend/tests/api/test.env
@@ -1,8 +1,11 @@
+LITELLM_MODEL_DEFAULT="gpt-3.5-turbo-1106"
+PROMETHEUS_MULTIPROC_DIR=/tmp
+# DB connection
 POSTGRES_USER=postgres-test-user
 POSTGRES_PASSWORD=postgres-test-pw
 POSTGRES_DB=postgres-test-db
 POSTGRES_PORT=5433
-REDIS_HOST="redis://localhost:6397"
-LITELLM_MODEL_DEFAULT="gpt-3.5-turbo-1106"
-PROMETHEUS_MULTIPROC_DIR=/tmp
+# Redis connection (as per Makefile)
+REDIS_HOST="redis://localhost:6381"
+# AlignScore connection (as per Makefile, if used)
 ALIGN_SCORE_API="http://localhost:5002/alignscore_base"

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - .env
     volumes:
       - db_volume:/var/lib/postgresql/data
-    ports: # Expose the port to port 5434 on the host machine
+    ports: # Expose the port to port 5434 on the host machine for debugging
       - 5434:5432
 
 volumes:

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -12,9 +12,8 @@ services:
       - .env
     volumes:
       - db_volume:/var/lib/postgresql/data
-    ports:
+    ports: # Expose the port to port 5434 on the host machine
       - 5434:5432
-
 
 volumes:
   db_volume:

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     restart: always
     env_file:
       - .env
+    depends_on:
+      - redis
     develop:
       watch:
         - action: rebuild
@@ -93,11 +95,13 @@ services:
       watch:
         - action: rebuild
           path: ../../optional_components/embeddings
+
   redis:
     image: "redis:6.0-alpine"
-    ports:
+    ports: # Expose the port to port 6380 on the host machine
       - "6380:6379"
     restart: always
+
 volumes:
   caddy_data:
   caddy_config:

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -98,7 +98,7 @@ services:
 
   redis:
     image: "redis:6.0-alpine"
-    ports: # Expose the port to port 6380 on the host machine
+    ports: # Expose the port to port 6380 on the host machine for debugging
       - "6380:6379"
     restart: always
 

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -40,8 +40,10 @@ BACKEND_ROOT_PATH="/api"
 # if not set, it will be set to "http://localhost:8000" in the front-end
 NEXT_PUBLIC_BACKEND_URL="https://localhost/api"
 
-# endpoint for the backend to call - must be set to the internal service name and port
+# LiteLLM Proxy endpoint for the backend to call
 LITELLM_ENDPOINT="http://litellm_proxy:4000"
+# Redis endpoint for the backend to call
+REDIS_HOST="redis://redis:6379"
 
 # Temporary folder for prometheus gunicorn multiprocess
 PROMETHEUS_MULTIPROC_DIR="/tmp"

--- a/deployment/docker-compose/template.env
+++ b/deployment/docker-compose/template.env
@@ -39,10 +39,9 @@ BACKEND_ROOT_PATH="/api"
 # if using a reverse proxy, the NEXT_PUBLIC_BACKEND_URL should be "https://$DOMAIN$BACKEND_ROOT_PATH"
 # if not set, it will be set to "http://localhost:8000" in the front-end
 NEXT_PUBLIC_BACKEND_URL="https://localhost/api"
-
-# LiteLLM Proxy endpoint for the backend to call
+# LiteLLM Proxy endpoint for the backend to call (must be container_name:port)
 LITELLM_ENDPOINT="http://litellm_proxy:4000"
-# Redis endpoint for the backend to call
+# Redis endpoint for the backend to call (must be container_name:port)
 REDIS_HOST="redis://redis:6379"
 
 # Temporary folder for prometheus gunicorn multiprocess


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 10mins

---

## Ticket

None - cleanup.

## Description

### Goals

- Make it easier to understand how ports are working for redis etc.
- Move the `add_dummy_data_to_db.py` so we can easily use it from inside the core_backend container when deployed (it will get auto-copied into the container this way)

## How has this been tested?

- make tests
- dev setup
  - with dev setup active, try running `python core_backend/add_dummy_data_to_db.py`
- docker compose
  - with docker-compose containers up, go into the core_backend container and run the script with `python add_dummy_data_to_db.py`

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
