### PR TITLE
Removing `exclude_archived` query parameter from search endpoint

### DIFF
--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -77,7 +77,6 @@ async def search(
     user_query: QueryBase,
     asession: AsyncSession = Depends(get_async_session),
     user_db: UserDB = Depends(authenticate_key),
-    exclude_archived: bool = True,
 ) -> QueryResponse | JSONResponse:
     """
     Search endpoint finds the most similar content to the user query and optionally
@@ -103,7 +102,7 @@ async def search(
         user_id=user_db.user_id,
         n_similar=int(N_TOP_CONTENT),
         asession=asession,
-        exclude_archived=exclude_archived,
+        exclude_archived=True,
     )
 
     await save_query_response_to_db(user_query_db, response, asession)


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: ~5 min

---

## Ticket

Fixes: N/A

## Description

### Goal

1. Remove `exclude_archived` as an explicit query parameter for the search parameter.

## How has this been tested?

1. All tests pass locally.

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts