### PR TITLE
UI: NavBar and top margin cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,9 @@ repos:
     rev: v1.92.0
     hooks:
       - id: terraform_fmt
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
-    hooks:
-      - id: detect-secrets
-        args: ["--baseline", ".secrets.baseline"]
-        exclude: package.lock.json
+  # - repo: https://github.com/Yelp/detect-secrets
+  #   rev: v1.5.0
+  #   hooks:
+  #     - id: detect-secrets
+  #       args: ["--baseline", ".secrets.baseline"]
+  #       exclude: package.lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,9 @@ repos:
     rev: v1.92.0
     hooks:
       - id: terraform_fmt
-  # - repo: https://github.com/Yelp/detect-secrets
-  #   rev: v1.5.0
-  #   hooks:
-  #     - id: detect-secrets
-  #       args: ["--baseline", ".secrets.baseline"]
-  #       exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: package.lock.json

--- a/admin_app/src/app/content/layout.tsx
+++ b/admin_app/src/app/content/layout.tsx
@@ -1,7 +1,7 @@
 import NavBar from "@/components/NavBar";
 import { ProtectedComponent } from "@/components/ProtectedComponent";
 import React from "react";
-import Grid from "@mui/material/Grid";
+import { Box } from "@mui/material";
 
 export default function RootLayout({
   children,
@@ -10,14 +10,8 @@ export default function RootLayout({
 }>) {
   return (
     <ProtectedComponent>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <NavBar />
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
-      </Grid>
+      <NavBar />
+      <Box paddingTop={"60px"}>{children}</Box>
     </ProtectedComponent>
   );
 }

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -72,26 +72,7 @@ const CardsPage = () => {
 
   return (
     <>
-      <Snackbar
-        open={snackMessage.message !== null}
-        autoHideDuration={6000}
-        onClose={() => {
-          setSnackMessage({ message: null, color: snackMessage.color });
-        }}
-      >
-        <Alert
-          onClose={() => {
-            setSnackMessage({ message: null, color: snackMessage.color });
-          }}
-          severity={snackMessage.color}
-          variant="filled"
-          sx={{ width: "100%" }}
-        >
-          {snackMessage.message}
-        </Alert>
-      </Snackbar>
-      <Layout.FlexBox alignItems="center" gap={sizes.baseGap}>
-        <Layout.Spacer multiplier={5} />
+      <Layout.FlexBox alignItems="center" gap={sizes.baseGap} paddingTop={8}>
         <Layout.FlexBox
           gap={sizes.smallGap}
           sx={{
@@ -106,7 +87,6 @@ const CardsPage = () => {
             sx={{ flexDirection: "row", justifyContent: "center" }}
             gap={sizes.smallGap}
           >
-            {/* <FilterListIcon sx={{ width: "auto", flexShrink: 0 }} /> */}
             <Autocomplete
               multiple
               limitTags={3}
@@ -143,6 +123,24 @@ const CardsPage = () => {
           setSnackMessage={setSnackMessage}
         />
       </Layout.FlexBox>
+      <Snackbar
+        open={snackMessage.message !== null}
+        autoHideDuration={6000}
+        onClose={() => {
+          setSnackMessage({ message: null, color: snackMessage.color });
+        }}
+      >
+        <Alert
+          onClose={() => {
+            setSnackMessage({ message: null, color: snackMessage.color });
+          }}
+          severity={snackMessage.color}
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          {snackMessage.message}
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/admin_app/src/app/dashboard/components/Overview.tsx
+++ b/admin_app/src/app/dashboard/components/Overview.tsx
@@ -17,7 +17,6 @@ import { format } from "date-fns";
 import React, { useEffect } from "react";
 import { ApexData, DayHourUsageData, Period, TopContentData } from "../types";
 
-
 interface OverviewProps {
   timePeriod: Period;
 }
@@ -251,7 +250,7 @@ const Overview: React.FC<OverviewProps> = ({ timePeriod }) => {
           flexDirection: "row",
           alignItems: "stretch",
           gap: 3,
-          pt: 3,
+          paddingTop: 3,
           maxWidth: 1387,
         }}
       >
@@ -278,7 +277,7 @@ const Overview: React.FC<OverviewProps> = ({ timePeriod }) => {
           <HeatMap data={heatmapData} options={heatmapOptions} />
         </Box>
       </Box>
-      <Box bgcolor="white" sx={{ mt: 2, maxWidth: 1387 }}>
+      <Box bgcolor="white" sx={{ marginTop: 2, maxWidth: 1387 }}>
         <TopContentTable rows={topContentData} />
         <Layout.Spacer multiplier={2} />
       </Box>

--- a/admin_app/src/app/dashboard/components/Sidebar.tsx
+++ b/admin_app/src/app/dashboard/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const Sidebar: React.FC<SideBarProps> = ({
         },
       }}
     >
-      <List sx={{ pt: 8 }}>
+      <List sx={{ paddingTop: 8 }}>
         <Box
           sx={{
             display: "flex",
@@ -70,7 +70,7 @@ const Sidebar: React.FC<SideBarProps> = ({
               }
               sx={{
                 display: "flex",
-                ml: 2,
+                marginLeft: 2,
                 alignContent: "stretch",
                 width: "90%",
                 borderRadius: 2,

--- a/admin_app/src/app/dashboard/components/StatCard.tsx
+++ b/admin_app/src/app/dashboard/components/StatCard.tsx
@@ -59,7 +59,7 @@ const StatCard: React.FC<StatCardProps> = ({
             sx={{
               fontSize: "2rem",
               fontWeight: "bold",
-              mr: 0.5,
+              marginRight: 0.5,
             }}
           >
             {value.toLocaleString()}

--- a/admin_app/src/app/dashboard/components/TabPanel.tsx
+++ b/admin_app/src/app/dashboard/components/TabPanel.tsx
@@ -28,7 +28,7 @@ const TabPanel: React.FC<TabPanelProps> = ({ tabValue, handleChange }) => {
             label={label}
             key={`tab-label-${index}`}
             value={tabLabels[label]}
-            sx={{ textTransform: "none", mr: 6 }}
+            sx={{ textTransform: "none", marginRight: 6 }}
           />
         ))}
       </Tabs>

--- a/admin_app/src/app/dashboard/layout.tsx
+++ b/admin_app/src/app/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 import NavBar from "@/components/NavBar";
 import { ProtectedComponent } from "@/components/ProtectedComponent";
 import React from "react";
-import Grid from "@mui/material/Grid";
+import { Box } from "@mui/material";
 
 export default function RootLayout({
   children,
@@ -10,14 +10,8 @@ export default function RootLayout({
 }>) {
   return (
     <ProtectedComponent>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <NavBar />
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
-      </Grid>
+      <NavBar />
+      <Box paddingTop={"60px"}>{children}</Box>
     </ProtectedComponent>
   );
 }

--- a/admin_app/src/app/dashboard/page.tsx
+++ b/admin_app/src/app/dashboard/page.tsx
@@ -31,45 +31,43 @@ const Dashboard: React.FC = () => {
   };
 
   return (
-    <>
-      <Box sx={{ display: "flex", mt: 4, flexDirection: "row" }}>
-        <Box sx={{ width: 240, display: "flex" }}>
-          <Sidebar
-            setDashboardPage={setDashboardPage}
-            selectedDashboardPage={dashboardPage}
-          />
-        </Box>
+    <Box sx={{ display: "flex", marginTop: 2, flexDirection: "row" }}>
+      <Box sx={{ width: 240, display: "flex" }}>
+        <Sidebar
+          setDashboardPage={setDashboardPage}
+          selectedDashboardPage={dashboardPage}
+        />
+      </Box>
+      <Box
+        sx={{
+          px: 3,
+          height: "100%",
+          flexGrow: 1,
+        }}
+      >
         <Box
           sx={{
-            px: 3,
-            height: "100%",
-            flexGrow: 1,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
           }}
         >
           <Box
             sx={{
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "space-between",
+              py: 2,
+              borderBottom: "1px solid",
+              borderBottomColor: "divider",
             }}
           >
-            <Box
-              sx={{
-                py: 2,
-                borderBottom: "1px solid",
-                borderBottomColor: "divider",
-              }}
-            >
-              <Typography variant="h4" color={appColors.primary}>
-                {dashboardPage}
-              </Typography>
-            </Box>
-            <TabPanel tabValue={timePeriod} handleChange={handleTabChange} />
-            <Box sx={{ flexGrow: 1 }}>{showPage()}</Box>
+            <Typography variant="h4" color={appColors.primary}>
+              {dashboardPage}
+            </Typography>
           </Box>
+          <TabPanel tabValue={timePeriod} handleChange={handleTabChange} />
+          <Box sx={{ flexGrow: 1 }}>{showPage()}</Box>
         </Box>
       </Box>
-    </>
+    </Box>
   );
 };
 

--- a/admin_app/src/app/integrations/components/ChatManagerGrid.tsx
+++ b/admin_app/src/app/integrations/components/ChatManagerGrid.tsx
@@ -47,7 +47,7 @@ const ChatManagerGrid = () => {
 
   return (
     <>
-      <Grid container spacing={sizes.baseGap} style={{ minWidth: 220 }}>
+      <Grid container spacing={sizes.baseGap} style={{ minWidth: 700 }}>
         {chatManagers.map((item, index) => (
           <Grid
             item

--- a/admin_app/src/app/integrations/components/ChatManagerModal.tsx
+++ b/admin_app/src/app/integrations/components/ChatManagerModal.tsx
@@ -53,7 +53,7 @@ const ChatManagerModal = ({
             sx={{
               maxHeight: "70vh",
               p: sizes.baseGap,
-              mr: sizes.baseGap,
+              marginRight: sizes.baseGap,
               overflowY: "auto",
             }}
           >

--- a/admin_app/src/app/integrations/components/ChatManagerModalContents.tsx
+++ b/admin_app/src/app/integrations/components/ChatManagerModalContents.tsx
@@ -35,7 +35,7 @@ const TypebotModalContent: React.FC = () => {
         In Typebot, you can use the "HTTPS request" card to call AAQ and receive
         its response.
       </Typography>
-      <Typography variant="body1" mb={sizes.baseGap}>
+      <Typography variant="body1" marginBottom={sizes.baseGap}>
         To get a head start, you can download our template below and load it
         into Typebot by going to "Create a typebot &gt; Import a file".
       </Typography>
@@ -53,7 +53,7 @@ const TypebotModalContent: React.FC = () => {
         </Button>
       </Box>
 
-      <Typography variant="body1" mt={sizes.doubleBaseGap}>
+      <Typography variant="body1" marginTop={sizes.doubleBaseGap}>
         Once loaded, you need to update the{" "}
         <code style={{ color: "tomato" }}>API_KEY</code> field inside the "HTTP
         request" card with your own API key before trying the flow.
@@ -82,7 +82,7 @@ const TurnModalContent: React.FC = () => {
           Open Turn Playbook
         </Button>
       </Box>
-      <Typography variant="body1" mb={sizes.baseGap}>
+      <Typography variant="body1" marginBottom={sizes.baseGap}>
         You can also refer to our{" "}
         <Link
           href="https://docs.ask-a-question.com/integrations/chat_managers/turn.io/turn/"
@@ -117,7 +117,7 @@ const GlificModalContent: React.FC = () => {
           Open Glific Flow
         </Button>
       </Box>
-      <Typography variant="body1" mb={sizes.baseGap}>
+      <Typography variant="body1" marginBottom={sizes.baseGap}>
         You can also refer to our{" "}
         <Link
           href="https://docs.ask-a-question.com/integrations/chat_managers/glific/glific/"

--- a/admin_app/src/app/integrations/layout.tsx
+++ b/admin_app/src/app/integrations/layout.tsx
@@ -1,7 +1,7 @@
 import NavBar from "@/components/NavBar";
 import { ProtectedComponent } from "@/components/ProtectedComponent";
 import React from "react";
-import Grid from "@mui/material/Grid";
+import { Box } from "@mui/material";
 
 export default function RootLayout({
   children,
@@ -10,14 +10,8 @@ export default function RootLayout({
 }>) {
   return (
     <ProtectedComponent>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <NavBar />
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
-      </Grid>
+      <NavBar />
+      <Box paddingTop={"60px"}>{children}</Box>
     </ProtectedComponent>
   );
 }

--- a/admin_app/src/app/integrations/page.tsx
+++ b/admin_app/src/app/integrations/page.tsx
@@ -26,17 +26,18 @@ const IntegrationsPage = () => {
   }, [accessLevel]);
 
   return (
-    <Layout.FlexBox alignItems="center">
-      <Layout.Spacer multiplier={5} />
+    <Layout.FlexBox
+      alignItems="center"
+      paddingTop={6}
+      paddingBottom={10}
+      gap={5}
+    >
       <KeyManagement
         token={token}
         editAccess={currAccessLevel === "fullaccess"}
       />
-      <Layout.Spacer multiplier={4} />
       <ChatManagers />
-      <Layout.Spacer multiplier={4} />
       <RestAPI />
-      <Layout.Spacer multiplier={6} />
     </Layout.FlexBox>
   );
 };
@@ -65,7 +66,7 @@ const KeyManagement = ({
           setCurrentKey(data.api_key_first_characters);
           const formatted_api_update_date = format(
             data.api_key_updated_datetime_utc,
-            "HH:mm, dd-MM-yyyy"
+            "HH:mm, dd-MM-yyyy",
           );
           setCurrentKeyLastUpdated(formatted_api_update_date);
           setKeyInfoFetchIsLoading(false);
@@ -114,7 +115,7 @@ const KeyManagement = ({
     <Layout.FlexBox
       key={"key-management"}
       flexDirection="column"
-      sx={{ maxWidth: 690, marginInline: 10 }}
+      sx={{ maxWidth: 700, marginInline: 10 }}
       gap={sizes.doubleBaseGap}
     >
       <Typography variant="h4" color="primary">
@@ -163,8 +164,8 @@ const KeyManagement = ({
               backgroundColor: keyGenerationIsLoading
                 ? appColors.lightGrey
                 : currentKey
-                  ? appColors.error
-                  : appColors.primary,
+                ? appColors.error
+                : appColors.primary,
             }}
           >
             {currentKey ? `Regenerate Key` : "Generate Key"}
@@ -193,7 +194,7 @@ const RestAPI = () => {
     <Layout.FlexBox
       key={"rest-api"}
       flexDirection="column"
-      sx={{ maxWidth: 690, marginInline: 10 }}
+      sx={{ maxWidth: 700, marginInline: 10 }}
       gap={sizes.doubleBaseGap}
     >
       <Typography variant="h4" color="primary">
@@ -231,7 +232,7 @@ const ChatManagers = () => {
     <Layout.FlexBox
       key={"chat-managers"}
       flexDirection="column"
-      sx={{ maxWidth: 1000, marginInline: 10 }}
+      sx={{ maxWidth: 700, marginInline: 10 }}
       gap={sizes.doubleBaseGap}
     >
       <Typography variant="h4" color="primary">

--- a/admin_app/src/app/playground/components/PlaygroundComponents.tsx
+++ b/admin_app/src/app/playground/components/PlaygroundComponents.tsx
@@ -155,7 +155,7 @@ const PersistentSearchBar = ({
               </InputAdornment>
             ),
             endAdornment: (
-              <InputAdornment position="end" sx={{ pr: 2 }}>
+              <InputAdornment position="end" sx={{ paddingRight: 2 }}>
                 <IconButton
                   onClick={() => {
                     onSend(queryText, selectedOption);
@@ -283,7 +283,7 @@ const MessageBox = ({
 
   const renderResults = (content: ResponseSummary[]) => {
     return content.map((c: ResponseSummary) => (
-      <Box sx={{ pb: sizes.smallGap }} key={c.index}>
+      <Box sx={{ paddingBottom: sizes.smallGap }} key={c.index}>
         <Typography component={"span"} variant="subtitle2">
           {Number(c.index) + 1}: {c.title}
         </Typography>
@@ -422,7 +422,7 @@ const MessageBox = ({
             <Typography
               component={"span"}
               id="modal-modal-description"
-              sx={{ mt: 2 }}
+              sx={{ marginTop: 2 }}
             >
               <pre
                 style={{

--- a/admin_app/src/app/playground/layout.tsx
+++ b/admin_app/src/app/playground/layout.tsx
@@ -1,7 +1,7 @@
 import NavBar from "@/components/NavBar";
 import { ProtectedComponent } from "@/components/ProtectedComponent";
 import React from "react";
-import Grid from "@mui/material/Grid";
+import { Box } from "@mui/material";
 
 export default function RootLayout({
   children,
@@ -10,14 +10,8 @@ export default function RootLayout({
 }>) {
   return (
     <ProtectedComponent>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <NavBar />
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
-      </Grid>
+      <NavBar />
+      <Box paddingTop={"60px"}>{children}</Box>
     </ProtectedComponent>
   );
 }

--- a/admin_app/src/app/playground/page.tsx
+++ b/admin_app/src/app/playground/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "./components/PlaygroundComponents";
 import { Box } from "@mui/material";
 import { useAuth } from "@/utils/auth";
+
 const Page = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
@@ -246,38 +247,33 @@ const Page = () => {
   };
 
   return (
-    <>
-      <Layout.Spacer multiplier={4} />
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      sx={{ paddingBottom: 15, paddingTop: 4 }}
+    >
       <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        sx={{ height: "90vh", width: "100%", pb: 10, mt: 4 }}
+        sx={{
+          width: "100%",
+          maxWidth: "lg",
+        }}
       >
-        <Box
-          mb={10}
-          sx={{
-            width: "100%",
-            maxWidth: "lg",
-            pb: 10,
-          }}
-        >
-          {messages.map((message, index) => (
-            <MessageBox
-              key={index}
-              message={message}
-              onFeedbackSend={sendResponseFeedback}
-            />
-          ))}
-          {loading && <MessageSkeleton />}
-          <div ref={bottomRef} />
-        </Box>
-        <ErrorSnackBar message={error} onClose={handleErrorClose} />
-        <Box sx={{ width: "100%", maxWidth: "lg", px: 2 }}>
-          <PersistentSearchBar onSend={onSend} />
-        </Box>
+        {messages.map((message, index) => (
+          <MessageBox
+            key={index}
+            message={message}
+            onFeedbackSend={sendResponseFeedback}
+          />
+        ))}
+        {loading && <MessageSkeleton />}
+        <div ref={bottomRef} />
       </Box>
-    </>
+      <ErrorSnackBar message={error} onClose={handleErrorClose} />
+      <Box sx={{ width: "100%", maxWidth: "lg", paddingLeft: 2 }}>
+        <PersistentSearchBar onSend={onSend} />
+      </Box>
+    </Box>
   );
 };
 

--- a/admin_app/src/app/urgency-rules/layout.tsx
+++ b/admin_app/src/app/urgency-rules/layout.tsx
@@ -1,7 +1,7 @@
 import NavBar from "@/components/NavBar";
 import { ProtectedComponent } from "@/components/ProtectedComponent";
 import React from "react";
-import Grid from "@mui/material/Grid";
+import { Box } from "@mui/material";
 
 export default function RootLayout({
   children,
@@ -10,14 +10,8 @@ export default function RootLayout({
 }>) {
   return (
     <ProtectedComponent>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <NavBar />
-        </Grid>
-        <Grid item xs={12}>
-          {children}
-        </Grid>
-      </Grid>
+      <NavBar />
+      <Box paddingTop={"60px"}>{children}</Box>
     </ProtectedComponent>
   );
 }

--- a/admin_app/src/app/urgency-rules/page.tsx
+++ b/admin_app/src/app/urgency-rules/page.tsx
@@ -143,12 +143,7 @@ const UrgencyRulesPage = () => {
   }, [token, accessLevel]);
 
   return (
-    <Layout.FlexBox
-      alignItems="center"
-      marginTop={6}
-      padding={5}
-      gap={sizes.baseGap}
-    >
+    <Layout.FlexBox alignItems="center" padding={5} gap={sizes.baseGap}>
       <Box
         sx={{
           display: "flex",
@@ -159,7 +154,7 @@ const UrgencyRulesPage = () => {
         }}
       >
         <Typography
-          sx={{ pl: 1, pt: 2 }}
+          sx={{ paddingLeft: 1, paddingTop: 2 }}
           variant="h4"
           align="left"
           color="primary"
@@ -243,11 +238,11 @@ const UrgencyRulesPage = () => {
                     onBlur={() => {
                       onBlur(index);
                     }}
-                    sx={{ pr: 12, pl: 0, marginBottom: 1 }}
+                    sx={{ paddingRight: 12, paddingLeft: 0, marginBottom: 1 }}
                     InputProps={{
                       style: { backgroundColor: "white" },
                       endAdornment: (
-                        <InputAdornment position="end" sx={{ pr: 2 }}>
+                        <InputAdornment position="end" sx={{ paddingRight: 2 }}>
                           <IconButton
                             onMouseDown={() => {
                               addOrUpdateItem(index);

--- a/admin_app/src/components/ContentModal.tsx
+++ b/admin_app/src/components/ContentModal.tsx
@@ -104,14 +104,17 @@ const ContentViewModal = ({
             sx={{
               maxHeight: "60vh", // this controls overall modal height too
               p: sizes.baseGap,
-              mr: sizes.baseGap,
+              marginRight: sizes.baseGap,
               overflowY: "auto",
               border: 1,
               borderColor: appColors.lightGrey,
               borderRadius: 3,
             }}
           >
-            <Typography variant="subtitle1" sx={{ mb: sizes.baseGap }}>
+            <Typography
+              variant="subtitle1"
+              sx={{ marginBottom: sizes.baseGap }}
+            >
               {title}
             </Typography>
             <Typography
@@ -166,7 +169,7 @@ const ContentViewModal = ({
               flexDirection={"row"}
               gap={sizes.baseGap}
               sx={{
-                pr: sizes.baseGap,
+                paddingRight: sizes.baseGap,
                 alignItems: "center",
                 justifyContent: "center",
               }}

--- a/admin_app/src/components/NavBar.tsx
+++ b/admin_app/src/components/NavBar.tsx
@@ -16,7 +16,6 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import { useState } from "react";
-import { Layout } from "./Layout";
 
 interface Page {
   title: string;
@@ -47,10 +46,8 @@ const NavBar = () => {
         appStyles.alignItemsCenter,
       ]}
     >
-      <Logo />
       <SmallScreenNavMenu />
       <LargeScreenNavMenu />
-      <Layout.Spacer horizontal multiplier={1.5} />
       <UserDropdown />
     </AppBar>
   );
@@ -65,7 +62,6 @@ const Logo = () => {
         sx={{
           height: 36,
           aspect_ratio: 1200 / 214,
-          display: { xs: "none", md: "block" },
         }}
       />
     </Link>
@@ -78,7 +74,16 @@ const SmallScreenNavMenu = () => {
     null,
   );
   return (
-    <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
+    <Box
+      alignItems="center"
+      gap={1.5}
+      paddingRight={1.5}
+      sx={{
+        height: sizes.navbar,
+        flexGrow: 1,
+        display: { xs: "flex", md: "none" },
+      }}
+    >
       <IconButton
         size="large"
         aria-label="account of current user"
@@ -91,6 +96,7 @@ const SmallScreenNavMenu = () => {
       >
         <MenuIcon />
       </IconButton>
+      <Logo />
       <Menu
         id="menu-appbar"
         anchorEl={anchorElNav}
@@ -177,97 +183,110 @@ const LargeScreenNavMenu = () => {
 
   return (
     <Box
-      justifyContent="flex-end"
+      justifyContent="space-between"
       alignItems="center"
-      sx={{ flexGrow: 1, display: { xs: "none", md: "flex", gap: 15 } }}
+      sx={{
+        height: sizes.navbar,
+        flexGrow: 1,
+        display: { xs: "none", md: "flex" },
+      }}
+      paddingLeft={0.5}
+      paddingRight={1.5}
     >
-      <Typography
-        onClick={handleConfigureClick}
-        sx={{
-          color:
-            pathname === "/content" || pathname === "/urgency-rules"
-              ? appColors.white
-              : appColors.outline,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          cursor: "pointer",
-        }}
+      <Logo />
+      <Box
+        justifyContent="flex-end"
+        alignItems="center"
+        sx={{ flexGrow: 1, display: "flex", gap: 1.5 }}
       >
-        {selectedOption} <ArrowDropDown />
-      </Typography>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={() => handleConfigureClose(null)}
-        sx={{
-          marginTop: "14px",
-          "& .MuiPaper-root": {
-            backgroundColor: appColors.primary,
-            color: "white",
-          },
-          "& .Mui-selected, & .MuiMenuItem-root:hover": {
-            backgroundColor: appColors.deeperPrimary,
-          },
-        }}
-      >
-        <MenuItem
-          onClick={() =>
-            handleConfigureClose({
-              title: "Manage Content",
-              path: "content",
-            })
-          }
-          style={{ color: "white" }}
+        <Typography
+          onClick={handleConfigureClick}
+          sx={{
+            color:
+              pathname === "/content" || pathname === "/urgency-rules"
+                ? appColors.white
+                : appColors.outline,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+          }}
         >
-          Manage Content
-        </MenuItem>
-        <MenuItem
-          onClick={() =>
-            handleConfigureClose({
-              title: "Manage Urgency Rules",
-              path: "urgency-rules",
-            })
-          }
+          {selectedOption} <ArrowDropDown />
+        </Typography>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          keepMounted
+          open={Boolean(anchorEl)}
+          onClose={() => handleConfigureClose(null)}
+          sx={{
+            marginTop: "14px",
+            "& .MuiPaper-root": {
+              backgroundColor: appColors.primary,
+              color: "white",
+            },
+            "& .Mui-selected, & .MuiMenuItem-root:hover": {
+              backgroundColor: appColors.deeperPrimary,
+            },
+          }}
         >
-          Manage Urgency Rules
-        </MenuItem>
-      </Menu>
-      {staticPages.map((page) => (
-        <Link
-          href={page.path}
-          key={page.title}
-          passHref
-          style={{ textDecoration: "none" }}
-        >
-          <Typography
-            key={page.title}
-            sx={{
-              margin: sizes.baseGap,
-              color:
-                pathname === page.path ? appColors.white : appColors.outline,
-            }}
+          <MenuItem
+            onClick={() =>
+              handleConfigureClose({
+                title: "Manage Content",
+                path: "content",
+              })
+            }
+            style={{ color: "white" }}
           >
-            {page.title}
-          </Typography>
-        </Link>
-      ))}
-      <Button
-        variant="outlined"
-        onClick={() => router.push("/dashboard")}
-        style={{
-          color:
-            pathname === "/dashboard" ? appColors.white : appColors.outline,
-          borderColor:
-            pathname === "/dashboard" ? appColors.white : appColors.outline,
-          maxHeight: "30px",
-          marginInline: 5,
-        }}
-      >
-        Dashboard
-      </Button>
+            Manage Content
+          </MenuItem>
+          <MenuItem
+            onClick={() =>
+              handleConfigureClose({
+                title: "Manage Urgency Rules",
+                path: "urgency-rules",
+              })
+            }
+          >
+            Manage Urgency Rules
+          </MenuItem>
+        </Menu>
+        {staticPages.map((page) => (
+          <Link
+            href={page.path}
+            key={page.title}
+            passHref
+            style={{ textDecoration: "none" }}
+          >
+            <Typography
+              key={page.title}
+              sx={{
+                margin: sizes.baseGap,
+                color:
+                  pathname === page.path ? appColors.white : appColors.outline,
+              }}
+            >
+              {page.title}
+            </Typography>
+          </Link>
+        ))}
+        <Button
+          variant="outlined"
+          onClick={() => router.push("/dashboard")}
+          style={{
+            color:
+              pathname === "/dashboard" ? appColors.white : appColors.outline,
+            borderColor:
+              pathname === "/dashboard" ? appColors.white : appColors.outline,
+            maxHeight: "30px",
+            marginInline: 5,
+          }}
+        >
+          Dashboard
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/admin_app/src/utils/index.ts
+++ b/admin_app/src/utils/index.ts
@@ -21,6 +21,7 @@ export const sizes = {
     medium: theme.spacing(4),
     large: theme.spacing(5),
   },
+  navbar: theme.spacing("60px"),
 };
 
 export const appColors = {

--- a/deployment/docker-compose/template.base.env
+++ b/deployment/docker-compose/template.base.env
@@ -1,8 +1,8 @@
 #### AAQ domain -- change for production ######################################
 DOMAIN="localhost"
 # Example value: `example.domain.com`
-# This is the domain that admin_app will be hosted on. core_backend will be hosted on
-# ${DOMAIN}/${BACKEND_ROOT_PATH}.
+# This is the domain that admin_app will be hosted on. core_backend will be
+# hosted on ${DOMAIN}/${BACKEND_ROOT_PATH}.
 
 BACKEND_ROOT_PATH="/api"
 # This is the path that core_backend will be hosted on.
@@ -10,8 +10,8 @@ BACKEND_ROOT_PATH="/api"
 
 #### Google OAuth Client ID ###################################################
 # NEXT_PUBLIC_GOOGLE_LOGIN_CLIENT_ID="update-me"
-# If you want to use Google OAuth, set the correct value for your production. This value
-# is used by core_backend and admin_app.
+# If you want to use Google OAuth, set the correct value for your production.
+# This value is used by core_backend and admin_app.
 
 #### Backend URL ##############################################################
 NEXT_PUBLIC_BACKEND_URL="https://${DOMAIN}${BACKEND_ROOT_PATH}"

--- a/deployment/docker-compose/template.core_backend.env
+++ b/deployment/docker-compose/template.core_backend.env
@@ -1,13 +1,13 @@
-# If not set, uses default values defined in core_backend/app/**/config.py files.
+# If not set, default values are loaded from core_backend/app/**/config.py files
 
-#### 🔒 Postgres variables -- change for production ############################
+#### 🔒 Postgres variables -- change for production ###########################
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres  #pragma: allowlist secret
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
 
-#### 🔒 Admin user -- change for production ####################################
+#### 🔒 Admin user -- change for production ###################################
 ADMIN_USERNAME="admin"
 ADMIN_PASSWORD="fullaccess" #pragma: allowlist secret
 ADMIN_API_KEY="admin-key"   #pragma: allowlist secret
@@ -33,7 +33,7 @@ LITELLM_ENDPOINT="http://localhost:4000"
 #EMBEDDINGS_IMAGE_NAME=text-embeddings-inference-arm
 #PGVECTOR_VECTOR_SIZE=1024
 
-#### Speech APIs ###############################################################
+#### Speech APIs ##############################################################
 # SPEECH_ENDPOINT=http://speech_service:8001/transcribe
 
 #### Temporary folder for prometheus gunicorn multiprocess ####################
@@ -69,7 +69,8 @@ LANGFUSE=False
 # LANGFUSE_PUBLIC_KEY="pk-..."
 # LANGFUSE_SECRET_KEY="sk-..."  #pragma: allowlist secret
 # Set LANGFUSE=True to enable Langfuse logging, and set the keys.
-# See https://docs.litellm.ai/docs/observability/langfuse_integration for more information.
+# See https://docs.litellm.ai/docs/observability/langfuse_integration for more
+# information.
 
 # Optional based on your Langfuse host:
 # LANGFUSE_HOST="https://cloud.langfuse.com"

--- a/deployment/docker-compose/template.litellm_proxy.env
+++ b/deployment/docker-compose/template.litellm_proxy.env
@@ -1,7 +1,7 @@
-# For every LLM API you decide to use, defined in litellm_proxy_config.yaml, ensure you
-# set up the correct authentication(s) here.
+# For every LLM API you decide to use, defined in litellm_proxy_config.yaml,
+# ensure you set up the correct authentication(s) here.
 
-#### 🔒 Vertex AI auth -- change for production ################################
+#### 🔒 Vertex AI auth -- change for production ###############################
 # Must be set if using VertexAI models
 GOOGLE_APPLICATION_CREDENTIALS="/app/credentials.json"
 # Path to the GCP credentials file *within* litellm_proxy container.
@@ -10,19 +10,19 @@ GOOGLE_APPLICATION_CREDENTIALS="/app/credentials.json"
 VERTEXAI_PROJECT="gcp-project-id-12345"
 VERTEXAI_LOCATION="us-central1"
 VERTEXAI_ENDPOINT="https://us-central1-aiplatform.googleapis.com"
-# Vertex AI endpoint. Note that you may want to increase the request quota from GCP's APIs
-# console.
+# Vertex AI endpoint. Note that you may want to increase the request quota from
+# GCP's APIs console.
 
-#### 🔒 OpenAI auth -- change for production ###################################
+#### 🔒 OpenAI auth -- change for production ##################################
 # Must be set if using OpenAI APIs.
 OPENAI_API_KEY="sk-..."
 
-#### 🔒 Huggingface embeddings -- change for production ########################
+#### 🔒 Huggingface embeddings -- change for production #######################
 # HUGGINGFACE_MODEL="Alibaba-NLP/gte-large-en-v1.5"
 # HUGGINGFACE_EMBEDDINGS_API_KEY="embeddings"  #pragma: allowlist secret
 # HUGGINGFACE_EMBEDDINGS_ENDPOINT="http://huggingface-embeddings"
 # This default endpoint value should work with docker compose.
 
-#### 🔒 LiteLLM Proxy UI -- change for production ##############################
+#### 🔒 LiteLLM Proxy UI -- change for production #############################
 # UI_USERNAME="admin"
 # UI_PASSWORD="admin"


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: 10mins

---

## Ticket

Fixes: None - cleanup

## Description

### Goal

- Make Large and Small navbars have the same height and standardise how we do top padding across pages
- Make all usages of margin or padding parameters verbose (mr -> marginRight, pt -> paddingTop, etc). Makes it much more readable and easy to see what's happening.

## How has this been tested?

- `npm run dev` and `npm run build`

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
