### PR TITLE
Use KEY=VALUE in Dockerfiles

### DIFF
--- a/admin_app/Dockerfile
+++ b/admin_app/Dockerfile
@@ -12,15 +12,15 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN npm run build
 
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -36,6 +36,6 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
 
 CMD ["node", "server.js"]

--- a/core_backend/Dockerfile
+++ b/core_backend/Dockerfile
@@ -17,8 +17,8 @@ RUN chown -R container_user: ${HOME_DIR}
 RUN mkdir /tmp/prometheus
 RUN chown -R container_user: /tmp/prometheus
 
-ENV PYTHONPATH "${PYTHONPATH}:${HOME_DIR}"
-ENV PORT ${PORT}
+ENV PYTHONPATH="${PYTHONPATH}:${HOME_DIR}"
+ENV PORT=${PORT}
 
 COPY . ${HOME_DIR}
 


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 5 min

---

## Ticket

Fixes: - 

## Description

### Goal

Was getting some warning from docker build process that we should use `ENV KEY=VALUE` syntax, rather than `ENV KEY VALUE` syntax.
https://docs.docker.com/reference/dockerfile/#env

### Changes

Changes all ENV statements to use `=`.

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts