### PR TITLE
Fix content limit schema

### DIFF
--- a/core_backend/app/users/schemas.py
+++ b/core_backend/app/users/schemas.py
@@ -11,7 +11,7 @@ class UserCreate(BaseModel):
     """
 
     username: str
-    content_quota: int
+    content_quota: Optional[int] = None
     api_daily_quota: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 5mins

---

## Ticket

Fixes: [HOTFIX]

## Description
This PR makes the user content_limit nullable so that users with unlimited contents can be added using the endpoint. 
### Goal

### Changes
- Made the `content_quota` optional in UserCreate
### Future Tasks (optional)

## How has this been tested?

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
