### PR TITLE
[AAQ-797] Refactor search base

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -231,15 +231,6 @@
         "line_number": 63
       }
     ],
-    "core_backend/app/question_answer/schemas.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "core_backend/app/question_answer/schemas.py",
-        "hashed_secret": "5b8b7a620e54e681c584f5b5c89152773c10c253",
-        "is_verified": false,
-        "line_number": 67
-      }
-    ],
     "core_backend/migrations/versions/2023_09_16_c5a948963236_create_query_table.py": [
       {
         "type": "Hex High Entropy String",
@@ -430,7 +421,7 @@
         "filename": "core_backend/tests/api/test_dashboard_overview.py",
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 290
       }
     ],
     "core_backend/tests/api/test_dashboard_performance.py": [
@@ -590,5 +581,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-23T09:41:17Z"
+  "generated_at": "2024-08-26T14:03:01Z"
 }

--- a/core_backend/app/contents/schemas.py
+++ b/core_backend/app/contents/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Annotated, List
+from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ContentCreate(BaseModel):
@@ -9,13 +9,15 @@ class ContentCreate(BaseModel):
     Pydantic model for content creation request
     """
 
-    content_title: Annotated[str, StringConstraints(max_length=150)] = Field(
+    content_title: str = Field(
+        max_length=150,
         examples=["Example Content Title"],
     )
-    content_text: Annotated[str, StringConstraints(max_length=2000)] = Field(
-        examples=["This is an example content."]
+    content_text: str = Field(
+        max_length=2000,
+        examples=["This is an example content."],
     )
-    content_tags: list = Field(default=[], examples=[[1, 4]])
+    content_tags: list = Field(default=[])
     content_metadata: dict = Field(default={}, examples=[{"key": "optional_value"}])
     is_archived: bool = False
 

--- a/core_backend/app/contents/schemas.py
+++ b/core_backend/app/contents/schemas.py
@@ -18,7 +18,7 @@ class ContentCreate(BaseModel):
         examples=["This is an example content."],
     )
     content_tags: list = Field(default=[])
-    content_metadata: dict = Field(default={}, examples=[{"key": "optional_value"}])
+    content_metadata: dict = Field(default={})
     is_archived: bool = False
 
     model_config = ConfigDict(

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -2,8 +2,6 @@
 Augmented Generation (RAG).
 """
 
-from typing import Optional
-
 from pydantic import ValidationError
 
 from ..config import LITELLM_MODEL_GENERATION
@@ -18,7 +16,7 @@ async def get_llm_rag_answer(
     question: str,
     context: str,
     original_language: IdentifiedLanguage,
-    metadata: Optional[dict] = None,
+    metadata: dict | None = None,
 ) -> RAG:
     """Get an answer from the LLM model using RAG.
 
@@ -32,7 +30,6 @@ async def get_llm_rag_answer(
         The language of the response.
     metadata
         Additional metadata to provide to the LLM model.
-
     Returns
     -------
     RAG

--- a/core_backend/app/llm_call/process_input.py
+++ b/core_backend/app/llm_call/process_input.py
@@ -121,6 +121,7 @@ def _process_identified_language_response(
 
         error_response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=response.llm_response,
             search_results=response.search_results,
@@ -206,6 +207,7 @@ async def _translate_question(
     else:
         error_response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=response.llm_response,
             search_results=response.search_results,
@@ -275,6 +277,7 @@ async def _classify_safety(
     else:
         error_response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=response.llm_response,
             search_results=response.search_results,
@@ -352,6 +355,7 @@ async def _paraphrase_question(
     else:
         error_response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=response.llm_response,
             search_results=response.search_results,

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -45,39 +45,7 @@ class AlignScoreData(TypedDict):
     claim: str
 
 
-def generate_llm_response__after(func: Callable) -> Callable:
-    """
-    Decorator to generate the LLM response.
-
-    Only runs if the generate_llm_response flag is set to True.
-    Requires "search_results" and "original_language" in the response.
-    """
-
-    @wraps(func)
-    async def wrapper(
-        query_refined: QueryRefined,
-        response: QueryResponse | QueryResponseError,
-        *args: Any,
-        **kwargs: Any,
-    ) -> QueryResponse | QueryResponseError:
-        """
-        Generate the LLM response
-        """
-        response = await func(query_refined, response, *args, **kwargs)
-
-        if not query_refined.generate_llm_response:
-            return response
-
-        metadata = create_langfuse_metadata(
-            query_id=response.query_id, user_id=query_refined.user_id
-        )
-        response = await _generate_llm_response(query_refined, response, metadata)
-        return response
-
-    return wrapper
-
-
-async def _generate_llm_response(
+async def generate_llm_query_response(
     query_refined: QueryRefined,
     response: QueryResponse,
     metadata: Optional[dict] = None,

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -281,6 +281,7 @@ def generate_tts__after(func: Callable) -> Callable:
             )
             response = QueryAudioResponse(
                 query_id=response.query_id,
+                session_id=response.session_id,
                 feedback_secret_key=response.feedback_secret_key,
                 llm_response=response.llm_response,
                 search_results=response.search_results,

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -82,6 +82,7 @@ async def generate_llm_query_response(
     else:
         response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=None,
             search_results=response.search_results,
@@ -187,6 +188,7 @@ async def _check_align_score(
         )
         response = QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=None,
             search_results=response.search_results,
@@ -329,6 +331,7 @@ async def _generate_tts_response(
         logger.error(f"Error generating TTS for query_id {response.query_id}: {e}")
         return QueryResponseError(
             query_id=response.query_id,
+            session_id=response.session_id,
             feedback_secret_key=response.feedback_secret_key,
             llm_response=response.llm_response,
             search_results=response.search_results,

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from litellm import acompletion
 
 from ..config import LITELLM_API_KEY, LITELLM_ENDPOINT, LITELLM_MODEL_DEFAULT
@@ -11,9 +9,9 @@ logger = setup_logger("LLM_call")
 async def _ask_llm_async(
     user_message: str,
     system_message: str,
-    litellm_model: Optional[str] = LITELLM_MODEL_DEFAULT,
-    litellm_endpoint: Optional[str] = LITELLM_ENDPOINT,
-    metadata: Optional[dict] = None,
+    litellm_model: str | None = LITELLM_MODEL_DEFAULT,
+    litellm_endpoint: str | None = LITELLM_ENDPOINT,
+    metadata: dict | None = None,
     json: bool = False,
 ) -> str:
     """

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -244,8 +244,7 @@ async def search(
             query_refined=user_query_refined_template,
             response=response,
         )
-    logger.info(f"Search response: {response}")
-    logger.debug(f"Search response type: {type(response)}")
+
     await save_query_response_to_db(user_query_db, response, asession)
     await increment_query_count(
         user_id=user_db.user_id,

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -311,7 +311,7 @@ async def get_search_response(
 
     search_results = await get_similar_content_async(
         user_id=user_id,
-        question=query_refined.query_text,
+        question=query_refined.query_text,  # use latest transformed version of the text
         n_similar=n_similar,
         asession=asession,
         metadata=metadata,

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -13,9 +13,9 @@ class QueryBase(BaseModel):
     """
 
     query_text: str = Field(..., examples=["What is AAQ?"])
-    session_id: Optional[int] = None
     generate_llm_response: bool = Field(False)
     query_metadata: dict = Field({}, examples=[{"some_key": "some_value"}])
+    session_id: int | None = Field(default=None, exclude=True)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -54,34 +54,25 @@ class QueryResponse(BaseModel):
     """
 
     query_id: int = Field(..., examples=[1])
-    session_id: Optional[int] = None
+    session_id: int | None = Field(None, exclude=True)
     feedback_secret_key: str = Field(..., examples=["secret-key-12345-abcde"])
     llm_response: str | None = Field(None, examples=["Example LLM response"])
 
     search_results: Dict[int, QuerySearchResult] | None = Field(
-        None,
         examples=[
             {
-                "query_id": 1,
-                "session_id": 1,
-                "feedback_secret_key": "secret-key-12345-abcde",
-                "llm_response": "Example LLM response "
-                "(null if generate_llm_response is false)",
-                "search_results": {
-                    "0": {
-                        "title": "Example content title",
-                        "text": "Example content text",
-                        "id": 23,
-                        "distance": 0.1,
-                    },
-                    "1": {
-                        "title": "Another example content title",
-                        "text": "Another example content text",
-                        "id": 12,
-                        "distance": 0.2,
-                    },
+                "0": {
+                    "title": "Example content title",
+                    "text": "Example content text",
+                    "id": 23,
+                    "distance": 0.1,
                 },
-                "debug_info": {"example": "debug-info"},
+                "1": {
+                    "title": "Another example content title",
+                    "text": "Another example content text",
+                    "id": 12,
+                    "distance": 0.2,
+                },
             }
         ],
     )
@@ -110,7 +101,7 @@ class QueryResponseError(QueryResponse):
     """
 
     error_type: ErrorType = Field(..., examples=["example_error"])
-    error_message: Optional[str] = Field(None, examples=["Example error message"])
+    error_message: str | None = Field(None, examples=["Example error message"])
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -122,11 +113,11 @@ class ResponseFeedbackBase(BaseModel):
     """
 
     query_id: int = Field(..., examples=[1])
-    session_id: Optional[int] = None
+    session_id: int | None = None
     feedback_sentiment: FeedbackSentiment = Field(
         FeedbackSentiment.UNKNOWN, examples=["positive"]
     )
-    feedback_text: Optional[str] = Field(None, examples=["This is helpful"])
+    feedback_text: str | None = Field(None, examples=["This is helpful"])
     feedback_secret_key: str = Field(..., examples=["secret-key-12345-abcde"])
 
     model_config = ConfigDict(from_attributes=True)

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Dict
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..llm_call.llm_prompts import IdentifiedLanguage
 from ..schemas import FeedbackSentiment, QuerySearchResult
@@ -15,7 +16,7 @@ class QueryBase(BaseModel):
     query_text: str = Field(..., examples=["What is AAQ?"])
     generate_llm_response: bool = Field(False)
     query_metadata: dict = Field({}, examples=[{"some_key": "some_value"}])
-    session_id: int | None = Field(default=None, exclude=True)
+    session_id: SkipJsonSchema[int | None] = Field(default=None, exclude=True)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -113,7 +114,7 @@ class ResponseFeedbackBase(BaseModel):
     """
 
     query_id: int = Field(..., examples=[1])
-    session_id: int | None = None
+    session_id: SkipJsonSchema[int | None] = None
     feedback_sentiment: FeedbackSentiment = Field(
         FeedbackSentiment.UNKNOWN, examples=["positive"]
     )

--- a/core_backend/app/question_answer/speech_components/utils.py
+++ b/core_backend/app/question_answer/speech_components/utils.py
@@ -1,9 +1,10 @@
 import os
 
+from fastapi import HTTPException
 from pydub import AudioSegment
 
 from ...llm_call.llm_prompts import IdentifiedLanguage
-from ...utils import setup_logger
+from ...utils import get_http_client, setup_logger
 
 logger = setup_logger("Voice utils")
 
@@ -80,3 +81,16 @@ def set_wav_specifications(wav_filename: str) -> str:
 
     logger.info(f"Updated file created: {updated_wav_filename}")
     return updated_wav_filename
+
+
+async def post_to_speech(file_path: str, endpoint_url: str) -> dict:
+    """
+    Post request the file to the speech endpoint to get the transcription
+    """
+    async with get_http_client() as client:
+        async with client.post(endpoint_url, json={"file_path": file_path}) as response:
+            if response.status != 200:
+                error_content = await response.json()
+                logger.error(f"Error from CUSTOM_SPEECH_ENDPOINT: {error_content}")
+                raise HTTPException(status_code=response.status, detail=error_content)
+            return await response.json()

--- a/core_backend/tests/api/test_dashboard_overview.py
+++ b/core_backend/tests/api/test_dashboard_overview.py
@@ -287,7 +287,6 @@ class TestHeatmap:
             for i in range(count):
                 query = QueryDB(
                     user_id=1,
-                    session_id=1,
                     feedback_secret_key="abc123",
                     query_text=f"test_{day}_{i}",
                     query_generate_llm_response=False,
@@ -321,7 +320,6 @@ class TestHeatmap:
             for i in range(count):
                 query = QueryDB(
                     user_id=1,
-                    session_id=1,
                     feedback_secret_key="abc123",
                     query_text=f"test_{hour}_{i}",
                     query_generate_llm_response=False,
@@ -512,7 +510,6 @@ class TestTimeSeries:
         for i in range(n_positive + n_negative + n_neutral):
             query = QueryDB(
                 user_id=user_id,
-                session_id=1,
                 feedback_secret_key="abc123",
                 query_text="test message",
                 query_generate_llm_response=False,


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 30 minutes

---

## Ticket

Fixes: https://idinsight.atlassian.net/browse/AAQ-797

## Description

### Goal

### Changes

1. Breaks down `search_base` into 
    1. `get_search_response` with __before rails, and 
    2. `get_generation_response` with __after rails
1. Cleaned up schema here and there
    1. Switched from Optional to union typing where applicable, following PEP 604 (credits to Oscar!) See: https://docs.python.org/3/library/stdtypes.html#union-type
    2. Don't display optional input fields like `session_id`. (Only did this for request json schema! so that users aren't confused.)

### Future Tasks (optional)

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the scripts in `scripts/`