### PR TITLE
Content snackbar and page 3 layout update

### DIFF
--- a/admin_app/src/app/content/edit/page.tsx
+++ b/admin_app/src/app/content/edit/page.tsx
@@ -160,6 +160,10 @@ const ContentBox = ({
   const [highlightedOption, setHighlightedOption] = React.useState<Tag | null>();
   const [isSaving, setIsSaving] = React.useState(false);
 
+  const setMainPageSnackMessage = (message: string): void => {
+    localStorage.setItem("editPageSnackMessage", message);
+  };
+
   const router = useRouter();
   React.useEffect(() => {
     const fetchTags = async () => {
@@ -181,6 +185,7 @@ const ContentBox = ({
 
     fetchTags();
   }, [refreshKey]);
+
   const saveContent = async (content: Content): Promise<number | null> => {
     setIsSaving(true);
 
@@ -215,6 +220,19 @@ const ContentBox = ({
       setIsSaving(false);
     }
   };
+
+  const handleSaveContent = async (content: Content) => {
+    const content_id = await saveContent(content);
+    if (content_id) {
+      {
+        content.content_id
+          ? setMainPageSnackMessage("Content edited successfully")
+          : setMainPageSnackMessage("Content created successfully");
+      }
+      router.push(`/content`);
+    }
+  };
+
   function createEmptyContent(contentTags: Tag[]): Content {
     return {
       content_id: null,
@@ -228,6 +246,7 @@ const ContentBox = ({
       content_metadata: {},
     };
   }
+
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     key: keyof Content,
@@ -242,6 +261,7 @@ const ContentBox = ({
       : setContent({ ...emptyContent, [key]: e.target.value });
     setIsSaved(false);
   };
+
   const handleTagsChange = (updatedTags: Tag[]) => {
     setContentTags(updatedTags);
     setIsSaved(false);
@@ -272,6 +292,7 @@ const ContentBox = ({
       setSnackMessage(`Tag "${tag}" already exists`);
     }
   };
+
   const openDeleteConfirmModal = (tag: Tag) => {
     setTagToDelete(tag);
     setOpenDeleteModal(true);
@@ -289,6 +310,7 @@ const ContentBox = ({
       });
     }
   };
+
   return (
     <Layout.FlexBox>
       <Dialog
@@ -500,15 +522,6 @@ const ContentBox = ({
               } else if (content.content_text === "") {
                 setIsContentEmpty(true);
               } else {
-                const handleSaveContent = async (content: Content) => {
-                  const content_id = await saveContent(content);
-                  if (content_id) {
-                    const actionType = content.content_id ? "edit" : "add";
-                    router.push(
-                      `/content/?content_id=${content_id}&action=${actionType}`,
-                    );
-                  }
-                };
                 handleSaveContent(content);
               }
             }}

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -103,7 +103,7 @@ const CardsPage = () => {
     }
   }, [accessLevel, token]);
 
-  const SlideTransition = (props: SlideProps) => {
+  const SnackbarSlideTransition = (props: SlideProps) => {
     return <Slide {...props} direction="up" />;
   };
 
@@ -215,7 +215,7 @@ const CardsPage = () => {
         onClose={() => {
           setSnackMessage({ message: null, color: snackMessage.color });
         }}
-        TransitionComponent={SlideTransition}
+        TransitionComponent={SnackbarSlideTransition}
       >
         <Alert
           onClose={() => {
@@ -421,8 +421,6 @@ const CardsGrid = ({
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
 
   const searchParams = useSearchParams();
-  const action = searchParams.get("action") || null;
-  const content_id = Number(searchParams.get("content_id")) || null;
 
   const calculateMaxCardsPerPage = () => {
     // set rows as per height of each card and height of grid (approximated from window height)
@@ -451,27 +449,6 @@ const CardsGrid = ({
     window.addEventListener("resize", calculateMaxCardsPerPage);
     return () => window.removeEventListener("resize", calculateMaxCardsPerPage);
   }, []);
-
-  const getSnackMessage = React.useCallback(
-    (action: string | null, content_id: number | null): string | null => {
-      if (action === "edit") {
-        return `Content updated`;
-      } else if (action === "add") {
-        return `Content created`;
-      }
-      return null;
-    },
-    [],
-  );
-
-  React.useEffect(() => {
-    if (action) {
-      setSnackMessage({
-        message: getSnackMessage(action, content_id),
-        color: "success",
-      });
-    }
-  }, [action, content_id, getSnackMessage]);
 
   const [refreshKey, setRefreshKey] = React.useState(0);
   const onSuccessfulArchive = (content_id: number) => {
@@ -511,6 +488,15 @@ const CardsGrid = ({
           setCards(filteredData);
           setMaxPages(Math.ceil(filteredData.length / maxCardsPerPage));
           setIsLoading(false);
+
+          const message = localStorage.getItem("editPageSnackMessage");
+          if (message) {
+            setSnackMessage({
+              message: message,
+              color: "success",
+            });
+            localStorage.removeItem("editPageSnackMessage");
+          }
         })
         .catch((error) => {
           console.error("Failed to fetch content:", error);

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -15,6 +15,8 @@ import {
   Menu,
   MenuItem,
   Paper,
+  Slide,
+  SlideProps,
   Snackbar,
   TextField,
   Tooltip,
@@ -30,7 +32,7 @@ import type { Content } from "@/app/content/edit/page";
 import ContentCard from "./components/ContentCard";
 import { DownloadModal } from "./components/DownloadModal";
 import { Layout } from "@/components/Layout";
-import { appStyles, appColors, LANGUAGE_OPTIONS, sizes } from "@/utils";
+import { appColors, LANGUAGE_OPTIONS, sizes } from "@/utils";
 import { apiCalls } from "@/utils/api";
 import { useAuth } from "@/utils/auth";
 import { ImportModal } from "./components/ImportModal";
@@ -100,6 +102,10 @@ const CardsPage = () => {
       setCurrAccessLevel("readonly");
     }
   }, [accessLevel, token]);
+
+  const SlideTransition = (props: SlideProps) => {
+    return <Slide {...props} direction="up" />;
+  };
 
   return (
     <>
@@ -205,10 +211,11 @@ const CardsPage = () => {
       </Grid>
       <Snackbar
         open={snackMessage.message !== null}
-        autoHideDuration={6000}
+        autoHideDuration={4000}
         onClose={() => {
           setSnackMessage({ message: null, color: snackMessage.color });
         }}
+        TransitionComponent={SlideTransition}
       >
         <Alert
           onClose={() => {

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -448,9 +448,9 @@ const CardsGrid = ({
   const getSnackMessage = React.useCallback(
     (action: string | null, content_id: number | null): string | null => {
       if (action === "edit") {
-        return `Content #${content_id} updated`;
+        return `Content updated`;
       } else if (action === "add") {
-        return `Content #${content_id} created`;
+        return `Content created`;
       }
       return null;
     },
@@ -471,7 +471,7 @@ const CardsGrid = ({
     setIsLoading(true);
     setRefreshKey((prevKey) => prevKey + 1);
     setSnackMessage({
-      message: `Content #${content_id} removed successfully`,
+      message: `Content removed successfully`,
       color: "success",
     });
   };
@@ -479,7 +479,7 @@ const CardsGrid = ({
     setIsLoading(true);
     setRefreshKey((prevKey) => prevKey + 1);
     setSnackMessage({
-      message: `Content #${content_id} deleted successfully`,
+      message: `Content deleted successfully`,
       color: "success",
     });
   };
@@ -618,7 +618,7 @@ const CardsGrid = ({
                         onSuccessfulArchive={onSuccessfulArchive}
                         onFailedArchive={(content_id: number) => {
                           setSnackMessage({
-                            message: `Failed to remove content #${content_id}`,
+                            message: `Failed to remove content`,
                             color: "error",
                           });
                         }}

--- a/admin_app/src/app/dashboard/components/Insights.tsx
+++ b/admin_app/src/app/dashboard/components/Insights.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { QueryData, Period, TopicModelingResponse } from "../types";
 import { generateNewTopics, fetchTopicsData } from "../api";
 import { useAuth } from "@/utils/auth";
+import { Paper } from "@mui/material";
 
 interface InsightProps {
   timePeriod: Period;
@@ -76,16 +77,31 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
   );
 
   return (
-    <Grid container sx={{ bgcolor: "grey.100", borderRadius: 2, mx: 0.5 }}>
-      <Grid
-        container
-        md={12}
-        columnSpacing={{ xs: 2 }}
-        sx={{ bgcolor: "white", borderRadius: 2, mx: 0.5, mt: 2, height: 400 }}
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Paper
+        elevation={0}
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          height: 400,
+          width: "100%",
+          border: 0.5,
+          borderColor: "lightgrey",
+        }}
       >
-        <Grid
-          md={3}
-          sx={{ p: 2, borderRight: 1, borderColor: "grey.300", borderWidth: 2 }}
+        <Box
+          sx={{
+            width: "25%",
+            padding: 2,
+            borderRight: 1,
+            borderColor: "grey.300",
+            borderWidth: 2,
+          }}
         >
           <Topics
             data={topics}
@@ -93,8 +109,13 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
             onClick={setSelectedTopicId}
             topicsPerPage={4}
           />
-        </Grid>
-        <Grid md={9} sx={{ p: 2 }}>
+        </Box>
+        <Box
+          sx={{
+            padding: 2,
+            width: "75%",
+          }}
+        >
           <Queries
             data={topicQueries}
             onRefreshClick={runRefresh}
@@ -102,18 +123,18 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
             lastRefreshed={dataFromBackend.refreshTimeStamp}
             refreshing={refreshing}
           />
-        </Grid>
-      </Grid>
-      <Grid
-        md={12}
-        height={400}
+        </Box>
+      </Paper>
+      <Paper
+        elevation={0}
         sx={{
-          bgcolor: "white",
-          borderRadius: 2,
-          mx: 0.5,
-          mt: 2,
+          width: "100%",
+          height: "400px",
+          marginTop: 2,
           justifyItems: "center",
           justifySelf: "stretch",
+          border: 0.5,
+          borderColor: "lightgrey",
         }}
       >
         <Box
@@ -125,10 +146,10 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
             justifyContent: "center",
           }}
         >
-          -- Chart - Coming Soon! --
+          Chart coming soon!
         </Box>
-      </Grid>
-    </Grid>
+      </Paper>
+    </Box>
   );
 };
 

--- a/admin_app/src/app/dashboard/components/Insights.tsx
+++ b/admin_app/src/app/dashboard/components/Insights.tsx
@@ -107,7 +107,7 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
             data={topics}
             selectedTopicId={selectedTopicId}
             onClick={setSelectedTopicId}
-            topicsPerPage={5}
+            topicsPerPage={8}
           />
         </Box>
         <Box

--- a/admin_app/src/app/dashboard/components/Insights.tsx
+++ b/admin_app/src/app/dashboard/components/Insights.tsx
@@ -88,7 +88,7 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
         sx={{
           display: "flex",
           flexDirection: "row",
-          height: 400,
+          height: 600,
           width: "100%",
           border: 0.5,
           borderColor: "lightgrey",
@@ -107,7 +107,7 @@ const Insight: React.FC<InsightProps> = ({ timePeriod }) => {
             data={topics}
             selectedTopicId={selectedTopicId}
             onClick={setSelectedTopicId}
-            topicsPerPage={4}
+            topicsPerPage={5}
           />
         </Box>
         <Box

--- a/admin_app/src/app/dashboard/components/Sidebar.tsx
+++ b/admin_app/src/app/dashboard/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import {
-  BarChart,
+  Category,
   ChevronLeft,
   ChevronRight,
   Dashboard,
-  Insights,
+  QueryStats,
 } from "@mui/icons-material";
 import {
   Box,
@@ -27,7 +27,7 @@ interface SideBarProps {
   selectedDashboardPage: PageName;
 }
 
-type PageName = "Overview" | "Content Performance" | "Content Gaps";
+type PageName = "Overview" | "Content Performance" | "Query Topics";
 
 interface MenuItem {
   name: PageName;
@@ -35,8 +35,8 @@ interface MenuItem {
 }
 const menuItems: MenuItem[] = [
   { name: "Overview", icon: <Dashboard /> },
-  { name: "Content Performance", icon: <BarChart /> },
-  { name: "Content Gaps", icon: <Insights /> },
+  { name: "Content Performance", icon: <QueryStats /> },
+  { name: "Query Topics", icon: <Category /> },
 ];
 const openedMixin = (theme: Theme): CSSObject => ({
   width: drawerWidth,

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -122,7 +122,7 @@ const Queries: React.FC<QueriesProps> = ({
           </Button>
         </Box>
       </Box>
-      <AISummary aiSummary={aiSummary} />
+      {data.length > 0 && <AISummary aiSummary={aiSummary} />}
       <Box
         sx={{
           display: "flex",

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -114,7 +114,7 @@ const Queries: React.FC<QueriesProps> = ({
             loadingPosition="start"
             sx={{
               bgcolor: orange[600],
-              width: 180,
+              width: 190,
               "&:hover": {
                 bgcolor: orange[800],
               },

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -163,7 +163,7 @@ const Queries: React.FC<QueriesProps> = ({
           </TableContainer>
         ) : (
           <Typography>
-            Run discovery to find topics for the selected time period.
+            Click "Run Discovery" to generate insights for this time period.
           </Typography>
         )}
       </Box>

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -90,10 +90,12 @@ const Queries: React.FC<QueriesProps> = ({
           display: "flex",
           flexDirection: "row",
           justifyContent: "space-between",
-          mb: 2,
+          marginBottom: 2,
         }}
       >
-        <Box sx={{ fontSize: 22, fontWeight: 700 }}>Example Queries</Box>
+        <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+          Example Queries
+        </Typography>
         <Box sx={{ display: "flex", flexDirection: "row" }}>
           <Box
             sx={{
@@ -163,7 +165,7 @@ const Queries: React.FC<QueriesProps> = ({
           </TableContainer>
         ) : (
           <Typography>
-            Run discovery to find topics for the selected time period.
+            Click Run Discovery to find topics for this time period.
           </Typography>
         )}
       </Box>

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -1,17 +1,17 @@
-import React from "react";
+import { AutoFixHigh } from "@mui/icons-material";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import { LoadingButton } from "@mui/lab";
 import { Box } from "@mui/material";
+import { grey, orange } from "@mui/material/colors";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { grey, orange } from "@mui/material/colors";
 import Typography from "@mui/material/Typography";
-import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
-import Button from "@mui/material/Button";
+import React from "react";
 import { QueryData } from "../../types";
-import CircularProgress from "@mui/material/CircularProgress";
 
 interface QueriesProps {
   data: QueryData[];
@@ -106,20 +106,23 @@ const Queries: React.FC<QueriesProps> = ({
           >
             Last run: {formattedLastRefreshed}
           </Box>
-          <Button
-            disabled={refreshing}
+          <LoadingButton
             variant="contained"
+            startIcon={<AutoFixHigh />}
+            disabled={refreshing}
+            loading={refreshing}
+            loadingPosition="start"
             sx={{
-              bgcolor: orange[500],
+              bgcolor: orange[600],
               width: 180,
               "&:hover": {
-                bgcolor: orange[700],
+                bgcolor: orange[800],
               },
             }}
             onClick={onRefreshClick}
           >
-            {refreshing ? <CircularProgress size={24} /> : "Re-run Discovery"}
-          </Button>
+            {data.length > 0 ? "Rerun Discovery" : "Run Discovery"}
+          </LoadingButton>
         </Box>
       </Box>
       {data.length > 0 && <AISummary aiSummary={aiSummary} />}
@@ -159,9 +162,9 @@ const Queries: React.FC<QueriesProps> = ({
             </Table>
           </TableContainer>
         ) : (
-          <Box sx={{ fontSize: "small" }}>
-            No queries found. Please re-run discovery
-          </Box>
+          <Typography>
+            Run discovery to find topics for the selected time period.
+          </Typography>
         )}
       </Box>
     </Box>

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -37,7 +37,7 @@ const AISummary: React.FC<AISummaryProps> = ({ aiSummary }) => {
         borderRadius: 2,
         background: "linear-gradient(to bottom, rgba(176,198,255,0.5), #ffffff)",
         p: 2,
-        mb: 3,
+        mb: 1,
       }}
     >
       <Box sx={{ display: "flex", flexDirection: "row", mb: 2 }}>
@@ -90,12 +90,10 @@ const Queries: React.FC<QueriesProps> = ({
           display: "flex",
           flexDirection: "row",
           justifyContent: "space-between",
-          marginBottom: 2,
+          mb: 1,
         }}
       >
-        <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-          Example Queries
-        </Typography>
+        <Box sx={{ fontSize: 22, fontWeight: 700 }}>Example Queries</Box>
         <Box sx={{ display: "flex", flexDirection: "row" }}>
           <Box
             sx={{
@@ -134,7 +132,7 @@ const Queries: React.FC<QueriesProps> = ({
           flexDirection: "column",
           overflow: "hidden",
           overflowY: "scroll",
-          maxHeight: 200,
+          maxHeight: 410,
         }}
       >
         {data.length > 0 ? (
@@ -165,7 +163,7 @@ const Queries: React.FC<QueriesProps> = ({
           </TableContainer>
         ) : (
           <Typography>
-            Click Run Discovery to find topics for this time period.
+            Run discovery to find topics for the selected time period.
           </Typography>
         )}
       </Box>

--- a/admin_app/src/app/dashboard/components/insights/Topics.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Topics.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Chip from "@mui/material/Chip";
 import ListItemButton from "@mui/material/ListItemButton";
 import { orange } from "@mui/material/colors";
@@ -43,11 +43,13 @@ const Topics: React.FC<TopicProps> = ({
         display: "flex",
         flexDirection: "column",
         justifyContent: "space-between",
-        height: 350,
+        height: "100%",
       }}
     >
       <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
-        <Box sx={{ mb: 1, fontSize: 22, fontWeight: 700 }}>Topics</Box>
+        <Typography variant="h6" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+          Topics
+        </Typography>
         {dataToShow.map((topic) => (
           <Box
             key={topic.topic_id}
@@ -76,7 +78,7 @@ const Topics: React.FC<TopicProps> = ({
                 justifyContent: "space-between",
                 borderRadius: 2,
                 my: 0.5,
-                ml: -0.5,
+                marginLeft: -0.5,
               }}
             >
               <Box>{topic.topic_name}</Box>

--- a/admin_app/src/app/dashboard/page.tsx
+++ b/admin_app/src/app/dashboard/page.tsx
@@ -26,7 +26,7 @@ const pages: Page[] = [
     description: "Track performance of contents  and identify areas for improvement",
   },
   {
-    name: "Content Gaps",
+    name: "Query Topics",
     description:
       "Find out what users are asking about to inform creating and updating contents",
   },
@@ -47,7 +47,7 @@ const Dashboard: React.FC = () => {
         return <Overview timePeriod={timePeriod} />;
       case "Content Performance":
         return <ContentPerformance timePeriod={timePeriod} />;
-      case "Content Gaps":
+      case "Query Topics":
         return <Insights timePeriod={timePeriod} />;
       default:
         return <div>Page not found.</div>;


### PR DESCRIPTION
Reviewer: @markbotterill 
Estimate: 15mins

---

## Ticket

Fixes: Cleanup

## Description

### Changes

- Contents page:
  - Updated snackbar to use localStorage instead of relying on URL parameters. This means that snackbars don't keep appearing on page reloads.
- dashboard page 3
  - Rename dashboard page 3 to "Query Topics" since we're not doing content gaps yet and updated the logos to nicer ones
  - Change layout to use Paper and Box instead of Grids
  - AI box doesn't show if discovery has never been run
  - Button is aware of whether discovery has been run or not.

## How has this been tested?

- dev

## Future tasks

- Save the refreshing state of the discovery button to localStorage (or some other way of tracking that the process is still ongoing) so that if the user changes tab / leaves and comes back the button still shows that it's still working...

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
