### PR TITLE
HOTFIX: shortened response from llm generation

### DIFF
--- a/core_backend/app/dashboard/models.py
+++ b/core_backend/app/dashboard/models.py
@@ -739,6 +739,7 @@ async def get_content_details(
             ContentFeedbackDB.feedback_datetime_utc >= start_date,
             ContentFeedbackDB.feedback_datetime_utc < end_date,
             ContentFeedbackDB.feedback_text.is_not(None),
+            ContentFeedbackDB.feedback_text != "",
         )
         .order_by(ContentFeedbackDB.feedback_datetime_utc.desc())
         .limit(max_feedback_records)

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -210,6 +210,7 @@ REFERENCE TEXT:
 
 IMPORTANT NOTES ON THE "answer" FIELD:
 - Answer in the language of the question ({original_language}).
+- Answer should be concise, to the point, and no longer than 80 words.
 - Do not include any information that is not present in the REFERENCE TEXT.
 """
 )


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 5 mins

---

## Ticket

* Fixes issue where "what can i eat?" fails on whatsapp frontedn since response is too long.
* Fixes issue where "Details Drawer" is also getting feedback with empty string
