### PR TITLE
Make redis optional and compatible with redis 5

### DIFF
--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -74,6 +74,7 @@ CHECK_CONTENT_LIMIT = os.environ.get("CHECK_CONTENT_LIMIT", True)
 DEFAULT_CONTENT_QUOTA = int(os.environ.get("DEFAULT_CONTENT_QUOTA", 50))
 DEFAULT_API_QUOTA = int(os.environ.get("DEFAULT_API_QUOTA", 100))
 CHECK_API_LIMIT = os.environ.get("CHECK_API_LIMIT", True)
+
 # Alignment Score variables
 ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -73,7 +73,7 @@ CROSS_ENCODER_MODEL = os.environ.get(
 CHECK_CONTENT_LIMIT = os.environ.get("CHECK_CONTENT_LIMIT", True)
 DEFAULT_CONTENT_QUOTA = int(os.environ.get("DEFAULT_CONTENT_QUOTA", 50))
 DEFAULT_API_QUOTA = int(os.environ.get("DEFAULT_API_QUOTA", 100))
-
+CHECK_API_LIMIT = os.environ.get("CHECK_API_LIMIT", True)
 # Alignment Score variables
 ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 20mins 

---

## Ticket

Fixes: [HOTFIX] Make redis compatible with redis 5 and make api limit checks optional

## Description

### Goal
Redis 5 is not compatible with the option: `keepttl`. This fix removes the use of `keepttl` to make it compatible.
This PR also makes api limit optional. 
### Changes

## How has this been tested?
- Tested api limit to make sure it 
## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
