### PR TITLE
[128] - Make External APIs for Speech compatabile with more filetypes 

### DIFF
--- a/core_backend/app/question_answer/speech_components/utils.py
+++ b/core_backend/app/question_answer/speech_components/utils.py
@@ -35,13 +35,14 @@ def get_gtts_lang_code_and_model(
 
 def convert_audio_to_wav(input_filename: str) -> str:
     """
-    Converts an MP3 or M4A file to a WAV file and ensures the WAV file has
-    the required specifications. Returns an error if the file format is unsupported.
+    Converts an audio file (MP3, M4A, OGG, FLAC, AAC, WebM, etc.) to a WAV file
+    and ensures the WAV file has the required specifications. Returns an error
+    if the file format is unsupported.
     """
 
     file_extension = input_filename.lower().split(".")[-1]
 
-    supported_formats = ["mp3", "m4a", "wav"]
+    supported_formats = ["mp3", "m4a", "wav", "ogg", "flac", "aac", "aiff", "webm"]
 
     if file_extension in supported_formats:
         if file_extension != "wav":
@@ -55,14 +56,8 @@ def convert_audio_to_wav(input_filename: str) -> str:
 
         return set_wav_specifications(wav_filename)
     else:
-        logger.error(
-            f"""Unsupported file format: {file_extension}.\
-    Only MP3, M4A, and WAV formats are supported."""
-        )
-        raise ValueError(
-            f"""Unsupported file format: {file_extension}.\
-    Only MP3, M4A, and WAV formats are supported."""
-        )
+        logger.error(f"""Unsupported file format: {file_extension}.""")
+        raise ValueError(f"""Unsupported file format: {file_extension}.""")
 
 
 def set_wav_specifications(wav_filename: str) -> str:

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -308,7 +308,19 @@ def get_file_extension_from_mime_type(mime_type: Optional[str]) -> str:
     mime_to_extension = {
         "audio/mpeg": ".mp3",
         "audio/wav": ".wav",
+        "audio/x-wav": ".wav",
         "audio/x-m4a": ".m4a",
+        "audio/aac": ".aac",
+        "audio/ogg": ".ogg",
+        "audio/flac": ".flac",
+        "audio/x-aiff": ".aiff",
+        "audio/aiff": ".aiff",
+        "audio/basic": ".au",
+        "audio/mid": ".midi",
+        "audio/x-midi": ".midi",
+        "audio/webm": ".webm",
+        "audio/x-ms-wma": ".wma",
+        "audio/x-ms-asf": ".asf",
     }
 
     if mime_type:


### PR DESCRIPTION
Reviewer: @amiraliemami 
Estimate: 5 min

---

## Ticket

Fixes: No Ticket link

## Description
Make the external api's more verbose by making it work with a lot of other file systems other than just m4a,wav,mp3.

### Goal
The goal of this PR is to make the google cloud `Speech to text` and `Text to speech` APIs more verbose so that they can handle transcription and synthesis for multiple file types now.

### Changes

### Future Tasks (optional)

## How has this been tested?
docker-compose 
swaggger UI
unit tests

Use the `voice-search` endpoint with any URL of the file of your choice (mp3,wav,m4a webm etc).

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
