### PR TITLE
[128] - Toggle /voice-search endpoint on/off

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,8 @@ env:
   POSTGRES_USER: postgres-test-user
   POSTGRES_DB: postgres-test-db
   REDIS_HOST: redis://redis:6379
+  TOGGLE_VOICE: custom
+
 jobs:
   container-job:
     runs-on: ubuntu-20.04
@@ -55,6 +57,7 @@ jobs:
         env:
           PROMETHEUS_MULTIPROC_DIR: /tmp
           REDIS_HOST: ${{ env.REDIS_HOST }}
+          TOGGLE_VOICE: ${{ env.TOGGLE_VOICE }}
         run: |
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 #!make
+SHELL := /bin/bash
 
 PROJECT_NAME = aaq
 CONDA_ACTIVATE=source $$(conda info --base)/etc/profile.d/conda.sh ; conda activate ; conda activate

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -1,4 +1,5 @@
 #!make
+SHELL := /bin/bash
 
 .PHONY : tests
 
@@ -49,4 +50,3 @@ teardown-redis-test:
 teardown-test-db:
 	@docker stop testdb
 	@docker rm testdb
-

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -83,6 +83,7 @@ ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 BACKEND_ROOT_PATH = os.environ.get("BACKEND_ROOT_PATH", "")
 
 # Speech API
+TOGGLE_SPEECH = os.environ.get("TOGGLE_SPEECH", None)
 CUSTOM_SPEECH_ENDPOINT = os.environ.get("CUSTOM_SPEECH_ENDPOINT", None)
 # Logging
 LANGFUSE = os.environ.get("LANGFUSE", "False")

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -83,7 +83,7 @@ ALIGN_SCORE_THRESHOLD = os.environ.get("ALIGN_SCORE_THRESHOLD", 0.7)
 BACKEND_ROOT_PATH = os.environ.get("BACKEND_ROOT_PATH", "")
 
 # Speech API
-TOGGLE_SPEECH = os.environ.get("TOGGLE_SPEECH", None)
+TOGGLE_VOICE = os.environ.get("TOGGLE_VOICE", None)
 CUSTOM_SPEECH_ENDPOINT = os.environ.get("CUSTOM_SPEECH_ENDPOINT", None)
 # Logging
 LANGFUSE = os.environ.get("LANGFUSE", "False")

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -16,7 +16,7 @@ from ..auth.dependencies import authenticate_key, rate_limiter
 from ..config import (
     CUSTOM_SPEECH_ENDPOINT,
     GCS_SPEECH_BUCKET,
-    TOGGLE_SPEECH,
+    TOGGLE_VOICE,
     USE_CROSS_ENCODER,
 )
 from ..contents.models import (
@@ -162,7 +162,7 @@ async def search(
     )
 
 
-if TOGGLE_SPEECH is not None:
+if TOGGLE_VOICE is not None:
 
     @router.post(
         "/voice-search",

--- a/core_backend/tests/api/test.env
+++ b/core_backend/tests/api/test.env
@@ -12,3 +12,4 @@ ALIGN_SCORE_API="http://localhost:5002/alignscore_base"
 # Speech Api endpoint
 # if u want to try the tests for the external TTS and STT apis then comment this out
 CUSTOM_SPEECH_ENDPOINT="http://localhost:8001/transcribe"
+TOGGLE_VOICE=custom

--- a/deployment/docker-compose/template.core_backend.env
+++ b/deployment/docker-compose/template.core_backend.env
@@ -34,11 +34,11 @@ LITELLM_ENDPOINT="http://localhost:4000"
 #PGVECTOR_VECTOR_SIZE=1024
 
 #### Speech APIs ###############################################################
-# Set this variable to 'External' or 'Custom' accordingly to toggle the /voice-search endpoint
+# Set this variable to 'external' or 'custom' accordingly to toggle the /voice-search endpoint
 # By default it is not set so it defaults to None
-# TOGGLE_SPEECH=External
+# TOGGLE_VOICE=external
 
-# if TOGGLE_SPEECH is set to 'Custom' then make sure to also set the Environment variables mentioned below
+# if TOGGLE_VOICE is set to 'Custom' then make sure to also set the Environment variables mentioned below
 # CUSTOM_SPEECH_ENDPOINT=http://speech_service:8001/transcribe
 
 #### Temporary folder for prometheus gunicorn multiprocess ####################

--- a/deployment/docker-compose/template.core_backend.env
+++ b/deployment/docker-compose/template.core_backend.env
@@ -34,6 +34,11 @@ LITELLM_ENDPOINT="http://localhost:4000"
 #PGVECTOR_VECTOR_SIZE=1024
 
 #### Speech APIs ###############################################################
+# Set this variable to 'External' or 'Custom' accordingly to toggle the /voice-search endpoint
+# By default it is not set so it defaults to None
+# TOGGLE_SPEECH=External
+
+# if TOGGLE_SPEECH is set to 'Custom' then make sure to also set the Environment variables mentioned below
 # CUSTOM_SPEECH_ENDPOINT=http://speech_service:8001/transcribe
 
 #### Temporary folder for prometheus gunicorn multiprocess ####################


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 10 min

---

## Ticket

Fixes: [JIRA_TICKET_LINK](https://idinsight.atlassian.net/browse/AAQ-819?atlOrigin=eyJpIjoiZjAxYWQ1Y2E1NTc2NGQyZDlmZjcyZjFjYjRjMGI0NDAiLCJwIjoiaiJ9)

## Description
This PR implements a feature to toggle the `/voice-search` endpoint on or off based on the `TOGGLE_VOICE` environment variable.

### Goal
To enhance endpoint design and user experience by making the `/voice-search` endpoint optional. This change also improves code readability and facilitates easier integration of external and custom models.

### Changes
- Added `TOGGLE_VOICE` environment variable to control `/voice-search` endpoint availability

## How has this been tested?

- Verified functionality using docker-compose
- Checked endpoint visibility in Swagger UI
- Updated and ran unit tests

### How to test this?
1. Set or unset the `TOGGLE_VOICE` environment variable
2. Observe changes in Swagger UI and endpoint accessibility

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests
- [x] I have updated the CI/CD scripts in `.github/workflows/`

