### PR TITLE
[AAQ-835] Enable LLM-less dashboards

### DIFF
--- a/admin_app/src/app/dashboard/components/ContentPerformance.tsx
+++ b/admin_app/src/app/dashboard/components/ContentPerformance.tsx
@@ -50,7 +50,13 @@ const ContentPerformance: React.FC<PerformanceProps> = ({ timePeriod }) => {
       });
 
       getPerformanceDrawerAISummary(timePeriod, contentId, token).then((response) => {
-        setDrawerAISummary(response.ai_summary);
+        if (response.ai_summary) {
+          setDrawerAISummary(response.ai_summary);
+        } else {
+          setDrawerAISummary(
+            "LLM functionality disabled on the backend. Please check your environment configuration if you wish to enable this feature.",
+          );
+        }
       });
     }
   };

--- a/admin_app/src/app/dashboard/components/insights/Queries.tsx
+++ b/admin_app/src/app/dashboard/components/insights/Queries.tsx
@@ -56,6 +56,7 @@ const AISummary: React.FC<AISummaryProps> = ({ aiSummary }) => {
       </Box>
       <Typography
         sx={{
+          whiteSpace: "pre-wrap",
           lineHeight: "15px",
           fontWeight: 300,
           fontSize: "small",
@@ -116,7 +117,7 @@ const Queries: React.FC<QueriesProps> = ({
             loadingPosition="start"
             sx={{
               bgcolor: orange[600],
-              width: 190,
+              width: 220,
               "&:hover": {
                 bgcolor: orange[800],
               },

--- a/core_backend/app/dashboard/config.py
+++ b/core_backend/app/dashboard/config.py
@@ -1,6 +1,8 @@
 import os
 
-GENERATE_AI_ANSWER = os.environ.get("GENERATE_AI_ANSWER", "True") == "True"
+DISABLE_DASHBOARD_LLM = (
+    os.environ.get("DISABLE_DASHBOARD_LLM", "false").lower() == "true"
+)
 MAX_FEEDBACK_RECORDS_FOR_AI_SUMMARY = os.environ.get(
     "MAX_FEEDBACK_RECORDS_FOR_AI_SUMMARY", 100
 )

--- a/core_backend/app/dashboard/models.py
+++ b/core_backend/app/dashboard/models.py
@@ -17,7 +17,7 @@ from ..question_answer.models import (
     ResponseFeedbackDB,
 )
 from ..urgency_detection.models import UrgencyResponseDB
-from .config import GENERATE_AI_ANSWER
+from .config import DISABLE_DASHBOARD_LLM
 from .schemas import (
     BokehContentItem,
     ContentFeedbackStats,
@@ -774,8 +774,8 @@ async def get_ai_answer_summary(
     Get AI answer summary
     """
 
-    if not GENERATE_AI_ANSWER:
-        return "Not Available"
+    if DISABLE_DASHBOARD_LLM:
+        return "Dashboard LLM features have been disabled in your backend configuration"
 
     user_feedback = (
         select(

--- a/core_backend/app/dashboard/models.py
+++ b/core_backend/app/dashboard/models.py
@@ -17,6 +17,7 @@ from ..question_answer.models import (
     ResponseFeedbackDB,
 )
 from ..urgency_detection.models import UrgencyResponseDB
+from ..utils import setup_logger
 from .config import DISABLE_DASHBOARD_LLM
 from .schemas import (
     BokehContentItem,
@@ -38,6 +39,9 @@ from .schemas import (
 )
 
 N_SAMPLES_TOPIC_MODELING = 4000
+
+
+logger = setup_logger()
 
 
 async def get_stats_cards(
@@ -769,13 +773,14 @@ async def get_ai_answer_summary(
     end_date: date,
     max_feedback_records: int,
     asession: AsyncSession,
-) -> str:
+) -> str | None:
     """
     Get AI answer summary
     """
 
     if DISABLE_DASHBOARD_LLM:
-        return "Dashboard LLM features have been disabled in your backend configuration"
+        logger.info("LLM functionality is disabled. Returning default message.")
+        return None
 
     user_feedback = (
         select(

--- a/core_backend/app/dashboard/schemas.py
+++ b/core_backend/app/dashboard/schemas.py
@@ -266,4 +266,4 @@ class AIFeedbackSummary(BaseModel):
     This class is used to define the schema for the AI feedback summary
     """
 
-    ai_summary: str
+    ai_summary: str | None

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -18,14 +18,10 @@ async def generate_ai_summary(
     content_title: str,
     content_text: str,
     feedback: list[str],
-) -> str:
+) -> str | None:
     """
     Generates AI summary for Page 2 of the dashboard.
     """
-    if DISABLE_DASHBOARD_LLM:
-        logger.info("LLM functionality is disabled. Returning default message.")
-        return """LLM functionality disabled on the backend. Please check your
-    environment configuration if you wish to enable this feature"""
 
     metadata = create_langfuse_metadata(feature_name="dashboard", user_id=user_id)
     ai_feedback_summary_prompt = get_feedback_summary_prompt(

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -1,6 +1,10 @@
 """
-These are LLM functions used by the dashbaord.
+These are LLM functions used by the dashboard.
 """
+
+import os
+
+from bertopic import BERTopic
 
 from ..config import LITELLM_MODEL_DASHBOARD_SUMMARY, LITELLM_MODEL_TOPIC_MODEL
 from ..utils import create_langfuse_metadata, setup_logger
@@ -8,6 +12,11 @@ from .llm_prompts import TopicModelLabelling, get_feedback_summary_prompt
 from .utils import _ask_llm_async
 
 logger = setup_logger("DASHBOARD AI SUMMARY")
+
+# Check if LLM functionalities are disabled
+DISABLE_DASHBOARD_LLM = (
+    os.environ.get("DISABLE_DASHBOARD_LLM", "false").lower() == "true"
+)
 
 
 async def generate_ai_summary(
@@ -19,6 +28,11 @@ async def generate_ai_summary(
     """
     Generates AI summary for the dashboard.
     """
+    if DISABLE_DASHBOARD_LLM:
+        logger.info("LLM functionality is disabled. Returning default message.")
+        return """LLM functionality disabled on the backend. Please check your
+    environment configuration if you wish to enable this feature"""
+
     metadata = create_langfuse_metadata(feature_name="dashboard", user_id=user_id)
     ai_feedback_summary_prompt = get_feedback_summary_prompt(
         content_title, content_text
@@ -40,13 +54,37 @@ async def generate_topic_label(
     user_id: int,
     context: str,
     sample_texts: list[str],
+    topic_model: BERTopic,
 ) -> dict[str, str]:
     """
-    Generates topic labels for example queries
+    Generates topic labels for example queries.
     """
     if topic_id == -1:
         return {"topic_title": "Unclassified", "topic_summary": "Not available."}
 
+    if DISABLE_DASHBOARD_LLM:
+        logger.info("LLM functionality is disabled. Generating labels using KeyBERT.")
+        # Use KeyBERT-inspired method to generate topic labels
+        # Assume topic_model is provided
+        topic_info = topic_model.get_topic(topic_id)
+        if not topic_info:
+            logger.warning(f"No topic info found for topic_id {topic_id}.")
+            return {"topic_title": "Unknown", "topic_summary": "Not available."}
+
+        # Extract top keywords
+        top_keywords = [word for word, _ in topic_info]
+        topic_title = ", ".join(top_keywords[:3])  # Use top 3 keywords as title
+        # Use all keywords as summary
+        # Line formatting looks odd since 'pre-wrap' is enabled on the frontend
+        topic_summary = f"""{" ".join(top_keywords)}
+
+Hint: To enable full AI summaries please set the DASHBOARD_LLM environment variable to "True" in your configuration."""  # noqa: E501
+        logger.info(
+            f"Generated topic label for topic_id {topic_id} using basic keywords."
+        )
+        return {"topic_title": topic_title, "topic_summary": topic_summary}
+
+    # If LLM is enabled, proceed with LLM-based label generation
     metadata = create_langfuse_metadata(feature_name="topic-modeling", user_id=user_id)
     topic_model_labelling = TopicModelLabelling(context)
 

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -2,21 +2,15 @@
 These are LLM functions used by the dashboard.
 """
 
-import os
-
 from bertopic import BERTopic
 
 from ..config import LITELLM_MODEL_DASHBOARD_SUMMARY, LITELLM_MODEL_TOPIC_MODEL
+from ..dashboard.config import DISABLE_DASHBOARD_LLM
 from ..utils import create_langfuse_metadata, setup_logger
 from .llm_prompts import TopicModelLabelling, get_feedback_summary_prompt
 from .utils import _ask_llm_async
 
 logger = setup_logger("DASHBOARD AI SUMMARY")
-
-# Check if LLM functionalities are disabled
-DISABLE_DASHBOARD_LLM = (
-    os.environ.get("DISABLE_DASHBOARD_LLM", "false").lower() == "true"
-)
 
 
 async def generate_ai_summary(

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -20,7 +20,7 @@ async def generate_ai_summary(
     feedback: list[str],
 ) -> str:
     """
-    Generates AI summary for the dashboard.
+    Generates AI summary for Page 2 of the dashboard.
     """
     if DISABLE_DASHBOARD_LLM:
         logger.info("LLM functionality is disabled. Returning default message.")

--- a/deployment/docker-compose/template.core_backend.env
+++ b/deployment/docker-compose/template.core_backend.env
@@ -19,6 +19,9 @@ ADMIN_API_KEY="admin-key"   #pragma: allowlist secret
 #### 🔒 JWT -- change for production ###########################################
 JWT_SECRET="jwt-secret"    #pragma: allowlist secret
 
+#### Dashboard settings #######################################################
+DISABLE_DASHBOARD_LLM=False
+
 #### Redis  -- change for production ##########################################
 REDIS_HOST="redis://localhost:6379"
 # For docker compose, use "redis://redis:6379"

--- a/docs/components/admin-app/dashboard/index.md
+++ b/docs/components/admin-app/dashboard/index.md
@@ -26,6 +26,12 @@ suggestion on how to improve the content.
 
 ![Dashboard Screenshot](./dashboard-pg2-drawer.jpeg)
 
+## AI Features
+
+Several parts of the dashboard use AI to provide LLM summaries and accurate topic labels. However,
+if data privacy is a concern a version of the dashboard that requires zero LLM calls (while maintaing all
+other features) can be activated by setting `DISABLE_DASHBOARD_LLM=True` in your core_backend.env
+
 ## Content Gaps
 
 :construction: Stay tuned for the "Content Gaps" section.


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 20 mins

---

## Ticket AAQ-835

Fixes: [JIRA_TICKET_LINK](https://idinsight.atlassian.net/browse/AAQ-835?atlOrigin=eyJpIjoiNzRkNWJhNjNlMDAzNDU3OWJhYTRlZmI3OTVmMWQzNjYiLCJwIjoiaiJ9)

## Description

Introduces new .env variable `DISABLE_DASHBOARD_LLM` to toggle P3 behavior. Replace `AI_SUMMARY` with this new variable to achieve similar effect. 

### Goal

First step to making an easy-switch LLM-less AAQ

### Changes

Changes in backend topic modeling pipeline for topic summaries. 

Small frontend bug fixed ("Run discovery" button was overflowing across lines") + enabled line formatting for one frontend box

### Future Tasks (optional)

Curate necessary changes required for `DISABLE_DASHBOARD_LLM` -> `DISABLE_LLM` to be app-wide. Execute changes. 

## How has this been tested?

Runs locally + passes GHA tests

## Checklist

Fill with `x` for completed. 

- [x ] My code follows the style guidelines of this project
- [ x] I have reviewed my own code to ensure good quality
- [ x] I have tested the functionality of my code to ensure it works as intended
- [x ] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
