### PR TITLE
HOTFIX for sorting issue when reranking search results

### DIFF
--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -376,9 +376,9 @@ def rerank_search_results(
         [(query_text, content.title + "\n" + content.text) for content in contents]
     )
 
-    sorted_by_score = [v for _, v in sorted(zip(scores, contents), reverse=True)][
-        :n_similar
-    ]
+    sorted_by_score = [
+        v for _, v in sorted(zip(scores, contents), key=lambda x: x[0], reverse=True)
+    ][:n_similar]
     reranked_search_results = dict(enumerate(sorted_by_score))
 
     return reranked_search_results


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: ~2 minutes

---

## Ticket

Fixes: N/A

## Description

Sorting the search results only needs to be done on the scores, not the contents. Fixed sorting so that it only uses the keys (i.e., the scores).

## Checklist

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts