### PR TITLE
Multiturn Conversation Backend

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ env:
   POSTGRES_PASSWORD: postgres-test-pw
   POSTGRES_USER: postgres-test-user
   POSTGRES_DB: postgres-test-db
-  REDIS_HOST: redis
+  REDIS_HOST: redis://redis:6379
 jobs:
   container-job:
     runs-on: ubuntu-20.04
@@ -59,7 +59,7 @@ jobs:
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
-            ALIGN_SCORE_API=$ALIGN_SCORE_API
+            ALIGN_SCORE_API=$ALIGN_SCORE_API REDIS_HOST=redis
           python -m alembic upgrade head
           python -m pytest -m "not rails and alembic" tests/api/test_alembic_migrations.py
           python -m pytest -m "not rails and not alembic" tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
-            ALIGN_SCORE_API=$ALIGN_SCORE_API REDIS_HOST=redis
+            ALIGN_SCORE_API=$ALIGN_SCORE_API
           python -m alembic upgrade head
           python -m pytest -m "not rails and alembic" tests/api/test_alembic_migrations.py
           python -m pytest -m "not rails and not alembic" tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
-            ALIGN_SCORE_API=$ALIGN_SCORE_API
+            ALIGN_SCORE_API=$ALIGN_SCORE_API REDIS_HOST=$REDIS_HOST
           python -m alembic upgrade head
           python -m pytest -m "not rails and alembic" tests/api/test_alembic_migrations.py
           python -m pytest -m "not rails and not alembic" tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ env:
   POSTGRES_PASSWORD: postgres-test-pw
   POSTGRES_USER: postgres-test-user
   POSTGRES_DB: postgres-test-db
-  REDIS_HOST: redis://redis:6379
+  REDIS_HOST: redis
 jobs:
   container-job:
     runs-on: ubuntu-20.04
@@ -59,7 +59,7 @@ jobs:
           cd core_backend
           export POSTGRES_HOST=postgres POSTGRES_USER=$POSTGRES_USER \
             POSTGRES_PASSWORD=$POSTGRES_PASSWORD POSTGRES_DB=$POSTGRES_DB \
-            ALIGN_SCORE_API=$ALIGN_SCORE_API REDIS_HOST=$REDIS_HOST
+            ALIGN_SCORE_API=$ALIGN_SCORE_API
           python -m alembic upgrade head
           python -m pytest -m "not rails and alembic" tests/api/test_alembic_migrations.py
           python -m pytest -m "not rails and not alembic" tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,8 @@ repos:
     hooks:
       - id: mypy
         exclude: ^data/|^scripts/
-        additional_dependencies: [types-PyYAML==6.0.12.12, types-python-dateutil, redis]
+        additional_dependencies:
+          [types-PyYAML==6.0.12.12, types-python-dateutil, redis, types-requests]
         args: [--ignore-missing-imports, --explicit-package-base]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3" # Use the sha / tag you want to point at

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,49 +354,49 @@
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "407c6798fe20fd5d75de4a233c156cc0fce510e3",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 46
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "42553e798bc193bcf25368b5e53ec7cd771483a7",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 50
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 51
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "70240b5d0947cc97447de496284791c12b2e678a",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 56
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "80fea3e25cb7e28550d13af9dfda7a9bd08c1a78",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 57
       },
       {
         "type": "Secret Keyword",
         "filename": "core_backend/tests/api/conftest.py",
         "hashed_secret": "3465834d516797458465ae4ed2c62e7020032c4e",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 317
       }
     ],
     "core_backend/tests/api/test.env": [
@@ -581,6 +581,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-02T16:16:48Z"
-
+  "generated_at": "2025-01-13T20:02:38Z"
 }

--- a/admin_app/src/app/content/components/ChatSideBar.tsx
+++ b/admin_app/src/app/content/components/ChatSideBar.tsx
@@ -1,0 +1,336 @@
+import React, { useEffect, useState } from "react";
+
+import TypingAnimation from "@/components/TypingAnimation";
+import { Close, Send } from "@mui/icons-material";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import CloseIcon from "@mui/icons-material/Close";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import {
+  Avatar,
+  Box,
+  CircularProgress,
+  Fade,
+  IconButton,
+  Link,
+  Modal,
+  Paper,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+
+import { appColors, sizes } from "@/utils";
+
+interface ResponseSummary {
+  index: string;
+  title: string;
+  text: string;
+}
+
+interface BaseMessage {
+  dateTime: string;
+  type: "question" | "response";
+}
+
+interface UserMessage extends BaseMessage {
+  type: "question";
+  content: string;
+}
+
+interface ResponseMessage extends BaseMessage {
+  type: "response";
+  content: ResponseSummary[] | string;
+  json: string;
+}
+
+type Message = UserMessage | ResponseMessage;
+
+const ChatSideBar = ({
+  closeSidebar,
+  getResponse,
+  setSnackMessage,
+}: {
+  closeSidebar: () => void;
+  getResponse: (question: string, session_id?: number) => Promise<any>;
+  setSnackMessage: (message: string) => void;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [question, setQuestion] = useState<string>("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [sessionId, setSessionId] = useState<number | null>(null);
+  const bottomRef = React.useRef<HTMLDivElement>(null); // Ref to scroll to bottom of chat
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, loading]);
+  const handleQuestionChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setQuestion(event.target.value);
+  };
+
+  const processErrorMessage = (error: Error) => {
+    setMessages((prevMessages) => [
+      ...prevMessages,
+      {
+        dateTime: new Date().toISOString(),
+        type: "response",
+        content: "API call failed. See JSON for details.",
+        json: `{error: ${error.message}}`,
+      },
+    ]);
+  };
+  const handleReset = () => {
+    setMessages([]);
+    setSessionId(null);
+  };
+  const handleSendClick = () => {
+    setQuestion("");
+    setMessages((prevMessages) => [
+      ...prevMessages,
+      {
+        dateTime: new Date().toISOString(),
+        type: "question",
+        content: question,
+      } as UserMessage,
+    ]);
+    setLoading(true);
+    const responsePromise = sessionId
+      ? getResponse(question, sessionId)
+      : getResponse(question);
+    responsePromise
+      .then((response) => {
+        const errorMessage = response.error
+          ? response.error.error_message
+          : "LLM Response failed.";
+        const responseMessage = {
+          dateTime: new Date().toISOString(),
+          type: "response",
+          content: response.status == 200 ? response.llm_response : errorMessage,
+          json: response,
+        } as ResponseMessage;
+
+        setMessages((prevMessages) => [...prevMessages, responseMessage]);
+        if (sessionId === null) {
+          setSessionId(response.session_id);
+        }
+      })
+      .catch((error: Error) => {
+        processErrorMessage(error);
+        setSnackMessage(error.message);
+        console.error(error);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return (
+    <Paper
+      elevation={2}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        padding: 3,
+        paddingTop: 4,
+        height: "94vh",
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        marginBottom={4}
+      >
+        <Typography variant="h6">Test Chat</Typography>
+        <IconButton onClick={closeSidebar}>
+          <Close />
+        </IconButton>
+      </Box>
+      <Box
+        sx={{
+          overflowY: "auto",
+          flexGrow: 1,
+        }}
+      >
+        {messages.map((message, index) => (
+          <MessageBox key={index} {...message} />
+        ))}
+        {loading ? (
+          <Box display="flex" alignItems="center">
+            <Avatar
+              alt="FA"
+              sx={{
+                mr: 1,
+                my: 1,
+                width: sizes.icons.medium,
+                height: sizes.icons.medium,
+                bgcolor: "primary.main",
+              }}
+            >
+              <AutoAwesomeIcon />
+            </Avatar>
+            <TypingAnimation />
+          </Box>
+        ) : null}
+        <div ref={bottomRef}></div>
+      </Box>
+      <Box display="flex" justifyContent="flex-end" margin={1}>
+        <Tooltip title="Reset conversation" aria-label="reset">
+          <IconButton
+            onClick={handleReset}
+            sx={{ color: appColors.primary }}
+            disabled={loading}
+          >
+            <RestartAltIcon />
+            <Typography variant="body2">Reset chat</Typography>
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Box
+        sx={{
+          padding: 2,
+          border: 1,
+          borderRadius: 1,
+          borderColor: "grey.400",
+        }}
+      >
+        <TextField
+          variant="standard"
+          placeholder="Ask a question..."
+          fullWidth
+          value={question}
+          onChange={handleQuestionChange}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && loading === false) {
+              handleSendClick();
+            }
+          }}
+          InputProps={{ disableUnderline: true }}
+        />
+        <Box
+          display="flex"
+          flexDirection="row"
+          justifyContent="flex-end"
+          paddingTop={2}
+        >
+          <IconButton
+            onClick={handleSendClick}
+            sx={{ color: appColors.primary }}
+            disabled={loading || question == "" ? true : false}
+          >
+            {loading ? <CircularProgress size={24} /> : <Send />}
+          </IconButton>
+        </Box>
+      </Box>
+    </Paper>
+  );
+};
+const MessageBox = (message: Message) => {
+  const [open, setOpen] = useState(false);
+  const toggleJsonModal = () => setOpen(!open);
+  const modalStyle = {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: "80%",
+    maxHeight: "80%",
+    flexGrow: 1,
+    bgcolor: "background.paper",
+    boxShadow: 24,
+    p: 4,
+    overflow: "scroll",
+    borderRadius: "10px",
+  };
+  const avatarOrder = message.type === "question" ? 2 : 0;
+  const contentOrder = 1;
+  const messageBubbleStyles = {
+    py: 1.5,
+    px: 2,
+    borderRadius: "15px",
+    bgcolor: message.type === "question" ? appColors.lightGrey : appColors.primary,
+    color: message.type === "question" ? "black" : "white",
+    maxWidth: "75%",
+    wordBreak: "break-word",
+    order: contentOrder,
+  };
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: message.type === "question" ? "flex-end" : "flex-start",
+        mb: 1,
+      }}
+    >
+      {message.type === "response" && (
+        <Avatar
+          alt="FA"
+          sx={{
+            mr: 1,
+            my: 1,
+            width: sizes.icons.medium,
+            height: sizes.icons.medium,
+            bgcolor: "primary.main",
+            alignSelf: "flex-end",
+            order: avatarOrder,
+          }}
+        >
+          <AutoAwesomeIcon />
+        </Avatar>
+      )}
+
+      <Box sx={messageBubbleStyles}>
+        <Typography component={"span"} variant="body1" align="left">
+          {typeof message.content === "string" ? message.content : null}
+        </Typography>
+        {message.hasOwnProperty("json") && (
+          <Link
+            onClick={toggleJsonModal}
+            variant="caption"
+            align="right"
+            underline="hover"
+            sx={{ cursor: "pointer", display: "block", color: appColors.white }}
+          >
+            {"<json>"}
+          </Link>
+        )}
+      </Box>
+
+      <Modal
+        open={open}
+        onClose={toggleJsonModal}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Fade in={!!open}>
+          <Box sx={modalStyle}>
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <IconButton onClick={toggleJsonModal}>
+                <CloseIcon />
+              </IconButton>
+            </Box>
+            <Typography component={"span"} id="modal-modal-description" sx={{ mt: 2 }}>
+              <pre
+                style={{
+                  backgroundColor: "#f5f5f5",
+                  border: "1px solid #ccc",
+                  padding: "10px",
+                  borderRadius: "10px",
+                  overflowX: "auto",
+                  fontFamily: "Courier, monospace",
+                }}
+              >
+                {"json" in message
+                  ? JSON.stringify(message.json, null, 2)
+                  : "No JSON message found"}
+              </pre>
+            </Typography>
+          </Box>
+        </Fade>
+      </Modal>
+    </Box>
+  );
+};
+export { ChatSideBar };

--- a/admin_app/src/app/content/components/SearchSidebar.tsx
+++ b/admin_app/src/app/content/components/SearchSidebar.tsx
@@ -366,7 +366,7 @@ const SearchResponseBox: React.FC<SearchResponseBoxProps> = ({
 const SearchSidebar = ({ closeSidebar }: { closeSidebar: () => void }) => {
   return (
     <TestSidebar
-      title="Test Question Answering"
+      title="Test Search"
       closeSidebar={closeSidebar}
       showLLMResponseToggle={true}
       handleSendClick={getSearchResponse}

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -38,6 +38,8 @@ import { ImportModal } from "./components/ImportModal";
 import { PageNavigation } from "./components/PageNavigation";
 import { SearchBar, SearchBarProps } from "./components/SearchBar";
 import { SearchSidebar } from "./components/SearchSidebar";
+import { ChatSideBar } from "./components/ChatSideBar";
+import { apiCalls } from "@/utils/api";
 
 const CARD_HEIGHT = 250;
 
@@ -74,14 +76,24 @@ const CardsPage = () => {
     color: "success" | "info" | "warning" | "error" | undefined;
   }>({ message: null, color: undefined });
 
-  const [openSidebar, setOpenSideBar] = useState(false);
+  const [openSearchSidebar, setOpenSideBar] = useState(false);
+  const [openChatSidebar, setOpenChatSideBar] = useState(false);
   const handleSidebarToggle = () => {
-    setOpenSideBar(!openSidebar);
+    setOpenChatSideBar(false);
+    setOpenSideBar(!openSearchSidebar);
+  };
+  const handleChatSidebarToggle = () => {
+    setOpenSideBar(false);
+    setOpenChatSideBar(!openChatSidebar);
+  };
+  const handleChatSidebarClose = () => {
+    setOpenChatSideBar(false);
   };
   const handleSidebarClose = () => {
+    setOpenChatSideBar(false);
     setOpenSideBar(false);
   };
-  const sidebarGridWidth = openSidebar ? 5 : 0;
+  const sidebarGridWidth = openSearchSidebar || openChatSidebar ? 5 : 0;
 
   React.useEffect(() => {
     if (token) {
@@ -115,7 +127,10 @@ const CardsPage = () => {
           md={12 - sidebarGridWidth}
           lg={12 - sidebarGridWidth + 1}
           sx={{
-            display: openSidebar ? { xs: "none", sm: "none", md: "block" } : "block",
+            display:
+              openSearchSidebar || openChatSidebar
+                ? { xs: "none", sm: "none", md: "block" }
+                : "block",
           }}
         >
           <Layout.FlexBox
@@ -168,43 +183,88 @@ const CardsPage = () => {
                   searchTerm={searchTerm}
                   tags={tags}
                   filterTags={filterTags}
-                  openSidebar={openSidebar}
+                  openSidebar={openSearchSidebar || openChatSidebar}
                   token={token}
                   accessLevel={currAccessLevel}
                   setSnackMessage={setSnackMessage}
                 />
-                {!openSidebar && (
-                  <Fab
-                    variant="extended"
-                    sx={{
-                      bgcolor: "orange",
-                      width: "100px",
-                      alignSelf: "flex-end",
-                      marginRight: 2,
-                      marginBottom: 3,
-                    }}
-                    onClick={handleSidebarToggle}
-                  >
-                    <PlayArrowIcon />
-                    <Layout.Spacer horizontal multiplier={0.3} />
-                    Test
-                  </Fab>
-                )}
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "flex-end",
+                    justifyContent: "flex-end",
+                    p: 1,
+                  }}
+                >
+                  {!openSearchSidebar && (
+                    <Fab
+                      variant="extended"
+                      sx={{
+                        bgcolor: "orange",
+                      }}
+                      onClick={handleSidebarToggle}
+                    >
+                      <PlayArrowIcon />
+                      <Layout.Spacer horizontal multiplier={0.3} />
+                      Test search
+                    </Fab>
+                  )}
+                  {!openChatSidebar && (
+                    <Fab
+                      variant="extended"
+                      sx={{
+                        bgcolor: "orange",
+                        ml: 2,
+                      }}
+                      onClick={handleChatSidebarToggle}
+                    >
+                      <PlayArrowIcon />
+                      <Layout.Spacer horizontal multiplier={0.3} />
+                      Test chat
+                    </Fab>
+                  )}
+                </Box>
               </Layout.FlexBox>
             </Box>
           </Layout.FlexBox>
         </Grid>
         <Grid
           item
-          xs={openSidebar ? 12 : 0}
-          sm={openSidebar ? 12 : 0}
+          xs={openSearchSidebar ? 12 : 0}
+          sm={openSearchSidebar ? 12 : 0}
           md={sidebarGridWidth}
           lg={sidebarGridWidth - 1}
           sx={{
-            display: openSidebar ? "block" : "none",
+            display: openSearchSidebar ? "block" : "none",
           }}
         >
           <SearchSidebar closeSidebar={handleSidebarClose} />
+        </Grid>
+        <Grid
+          item
+          xs={openChatSidebar ? 12 : 0}
+          sm={openChatSidebar ? 12 : 0}
+          md={sidebarGridWidth}
+          lg={sidebarGridWidth - 1}
+          sx={{
+            display: openChatSidebar ? "block" : "none",
+          }}
+        >
+          <ChatSideBar
+            closeSidebar={handleChatSidebarClose}
+            getResponse={(question: string, session_id) => {
+              return session_id
+                ? apiCalls.getChat(question, true, token!, session_id)
+                : apiCalls.getChat(question, true, token!);
+            }}
+            setSnackMessage={(message: string) => {
+              setSnackMessage({
+                message: message,
+                color: "error",
+              });
+            }}
+          />
         </Grid>
       </Grid>
       <Snackbar

--- a/admin_app/src/components/SidebarCommon.tsx
+++ b/admin_app/src/components/SidebarCommon.tsx
@@ -56,7 +56,7 @@ const TestSidebar = ({
       sx={{
         padding: 3,
         paddingTop: 4,
-        height: "100%",
+        height: "94vh",
       }}
     >
       <Box
@@ -111,7 +111,10 @@ const TestSidebar = ({
                 <Checkbox
                   checked={generateLLMResponse}
                   onChange={toggleGenerateLLMResponse}
-                  sx={{ color: "#5480D1", "&.Mui-checked": { color: "#5480D1" } }}
+                  sx={{
+                    color: "#5480D1",
+                    "&.Mui-checked": { color: "#5480D1" },
+                  }}
                 />
               }
               label="Also generate AI response"
@@ -136,15 +139,12 @@ const TestSidebar = ({
       </Box>
       <Box
         sx={{
+          flexGrow: 1,
           marginTop: 4,
           marginBottom: 4,
-          padding: 4,
+          padding: 2,
           overflowY: "scroll",
-          border: 1,
-          borderRadius: 1,
-          borderColor: "grey.400",
-          flexGrow: 1,
-          height: "65vh",
+          height: "75%",
         }}
       >
         {ResponseBox && (

--- a/admin_app/src/utils/api.ts
+++ b/admin_app/src/utils/api.ts
@@ -87,6 +87,36 @@ const getSearch = async (
   }
 };
 
+const getChat = async (
+  question: string,
+  generate_llm_response: boolean,
+  token: string,
+  session_id?: number,
+): Promise<{ status: number; data?: any; error?: any }> => {
+  try {
+    const response = await api.post(
+      "/chat",
+      {
+        query_text: question,
+        generate_llm_response,
+        session_id,
+      },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    return { status: response.status, ...response.data };
+  } catch (err) {
+    const error = err as AxiosError;
+    if (error.response) {
+      return { status: error.response.status, error: error.response.data };
+    } else {
+      console.error("Error returning chat response", error.message);
+      throw new Error(`Error returning chat response: ${error.message}`);
+    }
+  }
+};
 const postResponseFeedback = async (
   query_id: number,
   feedback_sentiment: string,
@@ -130,6 +160,7 @@ export const apiCalls = {
   getLoginToken,
   getGoogleLoginToken,
   getSearch,
+  getChat,
   postResponseFeedback,
   getUrgencyDetection,
 };

--- a/core_backend/add_dummy_data_to_db.py
+++ b/core_backend/add_dummy_data_to_db.py
@@ -15,12 +15,12 @@ from sqlalchemy.orm import Session
 # Append the framework path. NB: This is required if this script is invoked from the
 # command line. However, it is not necessary if it is imported from a pip install.
 if __name__ == "__main__":
-    PACKAGE_PATH = str(Path(__file__).resolve())
-    PACKAGE_PATH_SPLIT = PACKAGE_PATH.split(os.path.join("scripts"))
-    PACKAGE_PATH = PACKAGE_PATH_SPLIT[0]
+    PACKAGE_PATH_ROOT = str(Path(__file__).resolve())
+    PACKAGE_PATH_SPLIT = PACKAGE_PATH_ROOT.split(os.path.join("core_backend"))
+    PACKAGE_PATH = Path(PACKAGE_PATH_SPLIT[0]) / "core_backend"
     if PACKAGE_PATH not in sys.path:
         print(f"Appending '{PACKAGE_PATH}' to system path...")
-        sys.path.append(PACKAGE_PATH)
+        sys.path.append(str(PACKAGE_PATH))
 
 
 from app.config import PGVECTOR_VECTOR_SIZE

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -35,6 +35,7 @@ LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "dummy-key")
 # for all of its endpoints.
 LITELLM_MODEL_EMBEDDING = os.environ.get("LITELLM_MODEL_EMBEDDING", "openai/embeddings")
 LITELLM_MODEL_DEFAULT = os.environ.get("LITELLM_MODEL_DEFAULT", "openai/default")
+LITELLM_MODEL_CHAT = os.environ.get("LITELLM_MODEL_CHAT", "openai/chat")
 LITELLM_MODEL_GENERATION = os.environ.get(
     "LITELLM_MODEL_GENERATION", "openai/generate-response"
 )

--- a/core_backend/app/config.py
+++ b/core_backend/app/config.py
@@ -95,6 +95,7 @@ DB_POOL_SIZE = os.environ.get("DB_POOL_SIZE", 20)  # Number of connections in th
 
 # Redis
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis://localhost:6379")
+REDIS_CHAT_CACHE_EXPIRY_TIME = 3600
 
 # Google Cloud storage
 GCS_SPEECH_BUCKET = os.environ.get("GCS_SPEECH_BUCKET", "aaq-speech-test")

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -87,7 +87,7 @@ Hint: To enable full AI summaries please set the DASHBOARD_LLM environment varia
         system_message=topic_model_labelling.get_prompt(),
         litellm_model=LITELLM_MODEL_TOPIC_MODEL,
         metadata=metadata,
-        json=True,
+        json_=True,
     )
 
     try:

--- a/core_backend/app/llm_call/entailment.py
+++ b/core_backend/app/llm_call/entailment.py
@@ -42,7 +42,7 @@ async def detect_urgency(
         system_message=prompt,
         litellm_model=LITELLM_MODEL_URGENCY_DETECT,
         metadata=metadata,
-        json=True,
+        json_=True,
     )
 
     try:

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -466,7 +466,7 @@ class TopicModelLabelling:
 
 
 class ChatHistory:
-    default_system_message = textwrap.dedent(
+    system_message_construct_search_query = textwrap.dedent(
         """You are an AI assistant designed to help expecting and new mothers with
         their questions/concerns related to prenatal and newborn care. You interact
         with mothers via a chat interface.
@@ -492,7 +492,61 @@ class ChatHistory:
             - Use specific keywords that captures the semantic meaning of the mother's
             information needs.
 
-        Output the vector database query between the tags <Query> and </Query>, without
-        any additional text.
+        Do NOT attempt to answer the mother's question/concern. Only output the vector
+        database query between the tags <Query> and </Query>, without any additional
+        text.
+        """
+    )
+    system_message_generate_response = textwrap.dedent(
+        """You are an AI assistant designed to help expecting and new mothers with
+        their questions/concerns related to prenatal and newborn care. You interact
+        with mothers via a chat interface. You will be provided with ADDITIONAL
+        RELEVANT INFORMATION that can address the mother's questions/concerns.
+
+        BEFORE answering the mother's LATEST MESSAGE, follow these steps:
+
+        1. Review the conversation history to ensure that you understand the context in
+        which the mother's LATEST MESSAGE is being asked.
+        2. Review the provided ADDITIONAL RELEVANT INFORMATION to ensure that you
+        understand the most useful information related to the mother's LATEST MESSAGE.
+
+        When you have completed the above steps, you will then write a JSON, whose
+        TypeScript Interface is given below:
+
+        interface Response {{
+            extracted_info: string[];
+            answer: string;
+        }}
+
+        For "extracted_info", extract from the provided ADDITIONAL RELEVANT INFORMATION
+        the most useful information related to the LATEST MESSAGE asked by the mother,
+        and list them one by one. If no useful information is found, return an empty
+        list.
+
+        For "answer", understand the conversation history, ADDITIONAL RELEVANT
+        INFORMATION, and the mother's LATEST MESSAGE, and then provide an answer to the
+        mother's LATEST MESSAGE. If no useful information was found in the either the
+        conversation history or the ADDITIONAL RELEVANT INFORMATION, respond with
+        {failure_message}.
+
+        EXAMPLE RESPONSES:
+        {{"extracted_info": [
+            "Pineapples are a blend of pinecones and apples.",
+            "Pineapples have the shape of a pinecone."
+            ],
+          "answer": "The 'pine-' from pineapples likely come from the fact that \
+           pineapples are a hybrid of pinecones and apples and its pinecone-like \
+           shape."
+        }}
+        {{"extracted_info": [], "answer": "{failure_message}"}}
+
+        IMPORTANT NOTES ON THE "answer" FIELD:
+        - Answer in the language of the question ({original_language}).
+        - Answer should be concise and to the point.
+        - Do not include any information that is not present in the ADDITIONAL RELEVANT
+        INFORMATION.
+
+        Output the JSON response between tags <JSON> and </JSON>, without any
+        additional text.
         """
     )

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -463,3 +463,36 @@ class TopicModelLabelling:
             raise ValueError(f"Error validating the output: {e}") from e
 
         return result.model_dump()
+
+
+class ChatHistory:
+    default_system_message = textwrap.dedent(
+        """You are an AI assistant designed to help expecting and new mothers with
+        their questions/concerns related to prenatal and newborn care. You interact
+        with mothers via a chat interface.
+
+        For each message from a mother, follow these steps:
+
+        1. Determine the Type of Message:
+            - Follow-up Message: These are messages that build upon the conversation so
+            far and/or seeks more information on a previously discussed
+            question/concern.
+            - Clarification Message: These are messages that seek to clarify something
+            that was previously mentioned in the conversation.
+            - New Message: These are messages that introduce a new topic that was not
+            previously discussed in the conversation.
+
+        2. Obtain More Information to Help Address the Message:
+            - Keep in mind the context given by the conversation history thus far.
+            - Use the conversation history and the Type of Message to formulate a
+            precise query to execute against a vector database that contains
+            information relevant to the current message.
+            - Ensure the query is specific and accurately reflects the mother's
+            information needs.
+            - Use specific keywords that captures the semantic meaning of the mother's
+            information needs.
+
+        Output the vector database query between the tags <Query> and </Query>, without
+        any additional text.
+        """
+    )

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -471,9 +471,9 @@ class ChatHistory:
         their questions/concerns related to prenatal and newborn care. You interact
         with mothers via a chat interface.
 
-        For each message from a mother, follow these steps:
+        Your task is to analyze the mother's LATEST MESSAGE by following these steps:
 
-        1. Determine the Type of Message:
+        1. Determine the Type of the Mother's LATEST MESSAGE:
             - Follow-up Message: These are messages that build upon the conversation so
             far and/or seeks more information on a previously discussed
             question/concern.
@@ -482,13 +482,14 @@ class ChatHistory:
             - New Message: These are messages that introduce a new topic that was not
             previously discussed in the conversation.
 
-        2. Obtain More Information to Help Address the Message:
+        2. Obtain More Information to Help Address the Mother's LATEST MESSAGE:
             - Keep in mind the context given by the conversation history thus far.
-            - Use the conversation history and the Type of Message to formulate a
-            precise query to execute against a vector database that contains
-            information relevant to the current message.
-            - Ensure the query is specific and accurately reflects the mother's
-            information needs.
+            - Use the conversation history and the Type of the Mother's LATEST MESSAGE
+            to formulate a precise query to execute against a vector database in order
+            to retrieve the most relevant information that can address the mother's
+            latest message given the context of the conversation history.
+            - Ensure the vector database query is specific and accurately reflects the
+            mother's information needs.
             - Use specific keywords that captures the semantic meaning of the mother's
             information needs.
 
@@ -496,7 +497,7 @@ class ChatHistory:
         database query between the tags <Query> and </Query>, without any additional
         text.
         """
-    )
+    ).strip()
     system_message_generate_response = textwrap.dedent(
         """You are an AI assistant designed to help expecting and new mothers with
         their questions/concerns related to prenatal and newborn care. You interact
@@ -549,4 +550,4 @@ class ChatHistory:
         Output the JSON response between tags <JSON> and </JSON>, without any
         additional text.
         """
-    )
+    ).strip()

--- a/core_backend/app/llm_call/llm_prompts.py
+++ b/core_backend/app/llm_call/llm_prompts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import textwrap
 from enum import Enum
-from typing import ClassVar, Dict, List
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -222,7 +222,7 @@ class RAG(BaseModel):
 
     model_config = ConfigDict(strict=True)
 
-    extracted_info: List[str]
+    extracted_info: list[str]
     answer: str
 
     prompt: ClassVar[str] = RAG_RESPONSE_PROMPT
@@ -274,7 +274,7 @@ class UrgencyDetectionEntailment:
         probability: float = Field(ge=0, le=1)
         reason: str
 
-    _urgency_rules: List[str]
+    _urgency_rules: list[str]
     _prompt_base: str = textwrap.dedent(
         """
         You are a highly sensitive urgency detector. Score if ANY part of the
@@ -302,19 +302,19 @@ class UrgencyDetectionEntailment:
         """
     ).strip()
 
-    default_json: Dict = {
+    default_json: dict = {
         "best_matching_rule": "",
         "probability": 0.0,
         "reason": "",
     }
 
-    def __init__(self, urgency_rules: List[str]) -> None:
+    def __init__(self, urgency_rules: list[str]) -> None:
         """
         Initialize the urgency detection entailment task with urgency rules.
         """
         self._urgency_rules = urgency_rules
 
-    def parse_json(self, json_str: str) -> Dict:
+    def parse_json(self, json_str: str) -> dict:
         """
         Validates the output of the urgency detection entailment task.
         """
@@ -466,55 +466,61 @@ class TopicModelLabelling:
 
 
 class ChatHistory:
+    _valid_message_types = ["FOLLOW-UP", "NEW"]
     system_message_construct_search_query = format_prompt(
         prompt=textwrap.dedent(
-            """You are an AI assistant designed to help expecting and new mothers with
-            their questions/concerns related to prenatal and newborn care. You interact
-            with mothers via a chat interface.
+            """You are an AI assistant designed to help users with their
+            questions/concerns. You interact with users via a chat interface.
 
-            Your task is to analyze the mother's LATEST MESSAGE by following these
-            steps:
+            Your task is to analyze the user's LATEST MESSAGE by following these steps:
 
-            1. Determine the Type of the Mother's LATEST MESSAGE:
+            1. Determine the Type of the User's LATEST MESSAGE:
                 - Follow-up Message: These are messages that build upon the
-                conversation so far and/or seeks more information on a previously
-                discussed question/concern.
-                - Clarification Message: These are messages that seek to clarify
-                something that was previously mentioned in the conversation.
+                conversation so far and/or seeks more clarifying information on a
+                previously discussed question/concern.
                 - New Message: These are messages that introduce a new topic that was
                 not previously discussed in the conversation.
 
-            2. Obtain More Information to Help Address the Mother's LATEST MESSAGE:
+            2. Obtain More Information to Help Address the User's LATEST MESSAGE:
                 - Keep in mind the context given by the conversation history thus far.
-                - Use the conversation history and the Type of the Mother's LATEST
+                - Use the conversation history and the Type of the User's LATEST
                 MESSAGE to formulate a precise query to execute against a vector
                 database in order to retrieve the most relevant information that can
-                address the mother's LATEST MESSAGE given the context of the
-                conversation history.
+                address the user's LATEST MESSAGE given the context of the conversation
+                history.
                 - Ensure the vector database query is specific and accurately reflects
-                the mother's information needs.
+                the user's information needs.
                 - Use specific keywords that captures the semantic meaning of the
-                mother's information needs.
+                user's information needs.
 
-            Do NOT attempt to answer the mother's question/concern. Only output the
-            vector database query between the tags <Query> and </Query>, without any
-            additional text.
+            Output the following JSON response:
+
+            {{
+                "message_type": "The type of the user's LATEST MESSAGE. List of valid
+                options are: {valid_message_types},
+                "query": "The vector database query that you have constructed based on
+                the user's LATEST MESSAGE and the conversation history."
+            }}
+
+            Do NOT attempt to answer the user's question/concern. Only output the JSON
+            response, without any additional text.
             """
-        )
+        ),
+        prompt_kws={"valid_message_types": _valid_message_types},
     )
     system_message_generate_response = format_prompt(
         prompt=textwrap.dedent(
-            """You are an AI assistant designed to help expecting and new mothers with
-            their questions/concerns related to prenatal and newborn care. You interact
-            with mothers via a chat interface. You will be provided with ADDITIONAL
-            RELEVANT INFORMATION that can address the mother's questions/concerns.
+            """You are an AI assistant designed to help users with their
+            questions/concerns. You interact with users via a chat interface. You will
+            be provided with ADDITIONAL RELEVANT INFORMATION that can address the
+            user's questions/concerns.
 
-            BEFORE answering the mother's LATEST MESSAGE, follow these steps:
+            BEFORE answering the user's LATEST MESSAGE, follow these steps:
 
             1. Review the conversation history to ensure that you understand the
-            context in which the mother's LATEST MESSAGE is being asked.
+            context in which the user's LATEST MESSAGE is being asked.
             2. Review the provided ADDITIONAL RELEVANT INFORMATION to ensure that you
-            understand the most useful information related to the mother's LATEST
+            understand the most useful information related to the user's LATEST
             MESSAGE.
 
             When you have completed the above steps, you will then write a JSON, whose
@@ -527,12 +533,12 @@ class ChatHistory:
 
             For "extracted_info", extract from the provided ADDITIONAL RELEVANT
             INFORMATION the most useful information related to the LATEST MESSAGE asked
-            by the mother, and list them one by one. If no useful information is found,
+            by the user, and list them one by one. If no useful information is found,
             return an empty list.
 
             For "answer", understand the conversation history, ADDITIONAL RELEVANT
-            INFORMATION, and the mother's LATEST MESSAGE, and then provide an answer to
-            the mother's LATEST MESSAGE. If no useful information was found in the
+            INFORMATION, and the user's LATEST MESSAGE, and then provide an answer to
+            the user's LATEST MESSAGE. If no useful information was found in the
             either the conversation history or the ADDITIONAL RELEVANT INFORMATION,
             respond with {failure_message}.
 
@@ -541,20 +547,65 @@ class ChatHistory:
                 "Pineapples are a blend of pinecones and apples.",
                 "Pineapples have the shape of a pinecone."
                 ],
-              "answer": "The 'pine-' from pineapples likely come from the fact that \
-               pineapples are a hybrid of pinecones and apples and its pinecone-like \
+              "answer": "The 'pine-' from pineapples likely come from the fact that
+               pineapples are a hybrid of pinecones and apples and its pinecone-like
                shape."
             }}
             {{"extracted_info": [], "answer": "{failure_message}"}}
 
             IMPORTANT NOTES ON THE "answer" FIELD:
+            - Keep in mind that the user is asking a {message_type} question.
             - Answer in the language of the question ({original_language}).
             - Answer should be concise and to the point.
             - Do not include any information that is not present in the ADDITIONAL
             RELEVANT INFORMATION.
 
-            Output the JSON response between tags <JSON> and </JSON>, without any
-            additional text.
+            Only output the JSON response, without any additional text.
             """
         )
     )
+
+    class ChatHistoryConstructSearchQuery(BaseModel):
+        """Pydantic model for the output of the construct search query chat history."""
+
+        message_type: Literal["FOLLOW-UP", "NEW"]
+        query: str
+
+    @staticmethod
+    def parse_json(*, chat_type: Literal["search"], json_str: str) -> dict[str, str]:
+        """Validate the output of the chat history search query response.
+
+        Parameters
+        ----------
+        chat_type
+            The chat type. The chat type is used to determine the appropriate Pydantic
+            model to validate the JSON response.
+        json_str : str
+            The JSON string to validate.
+
+        Returns
+        -------
+        dict[str, str]
+            The validated JSON response.
+
+        Raises
+        ------
+        NotImplementedError
+            If the Pydantic model for the chat type is not implemented.
+        ValueError
+            If the JSON string is not valid.
+        """
+
+        match chat_type:
+            case "search":
+                pydantic_model = ChatHistory.ChatHistoryConstructSearchQuery
+            case _:
+                raise NotImplementedError(
+                    f"Pydantic model for chat type '{chat_type}' is not implemented."
+                )
+        try:
+            return pydantic_model.model_validate_json(
+                remove_json_markdown(json_str)
+            ).model_dump()
+        except ValueError as e:
+            raise ValueError(f"Error validating the output: {e}") from e

--- a/core_backend/app/llm_call/llm_rag.py
+++ b/core_backend/app/llm_call/llm_rag.py
@@ -2,12 +2,20 @@
 Augmented Generation (RAG).
 """
 
+from typing import Any
+
 from pydantic import ValidationError
 
 from ..config import LITELLM_MODEL_GENERATION
 from ..utils import setup_logger
 from .llm_prompts import RAG, IdentifiedLanguage
-from .utils import _ask_llm_async, remove_json_markdown
+from .utils import (
+    _ask_llm_async,
+    append_message_to_chat_history,
+    get_chat_response,
+    remove_json_markdown,
+    strip_tags,
+)
 
 logger = setup_logger("RAG")
 
@@ -26,8 +34,8 @@ async def get_llm_rag_answer(
         The question to ask the LLM model.
     context
         The context to provide to the LLM model.
-    response_language
-        The language of the response.
+    original_language
+        The original language of the question.
     metadata
         Additional metadata to provide to the LLM model.
     Returns
@@ -56,3 +64,83 @@ async def get_llm_rag_answer(
         response = RAG(extracted_info=[], answer=result)
 
     return response
+
+
+async def get_llm_rag_answer_with_chat_history(
+    *,
+    chat_history: list[dict[str, str]],
+    chat_params: dict[str, Any],
+    context: str,
+    metadata: dict | None = None,
+    question: str,
+    session_id: str,
+) -> tuple[RAG, list[dict[str, str]]]:
+    """Get an answer from the LLM model using RAG with chat history.
+
+    Parameters
+    ----------
+    chat_history
+        The chat history.
+    chat_params
+        The chat parameters.
+    context
+        The context to provide to the LLM model.
+    metadata
+        Additional metadata to provide to the LLM model.
+    question
+        The question to ask the LLM model.
+    session_id
+        The session id for the chat.
+
+    Returns
+    -------
+    tuple[RAG, list[dict[str, str]]
+        The RAG response object and the updated chat history.
+    """
+
+    content = (
+        question
+        + f""""\n\n
+    ADDITIONAL RELEVANT INFORMATION BELOW
+    =====================================
+
+    {context}
+
+    ADDITIONAL RELEVANT INFORMATION ABOVE
+    =====================================
+    """
+    )
+    chat_history, content = await get_chat_response(
+        chat_history=chat_history,
+        chat_params=chat_params,
+        original_message_params=content,
+        session_id=session_id,
+        json=True,
+        metadata=metadata or {},
+    )
+    result = strip_tags(tag="JSON", text=content)[0]
+    result = remove_json_markdown(result)
+    try:
+        response = RAG.model_validate_json(result)
+    except ValidationError as e:
+        logger.error(f"RAG output is not a valid json: {e}")
+        response = RAG(extracted_info=[], answer=result)
+
+    # First pop is the assistant response.
+    _, last_user_content = chat_history.pop(), chat_history.pop()
+    last_user_content["content"] = question
+    chat_history = append_message_to_chat_history(
+        chat_history=chat_history,
+        message=last_user_content,
+        model=chat_params["model"],
+        model_context_length=chat_params["max_input_tokens"],
+        total_tokens_for_next_generation=chat_params["max_output_tokens"],
+    )
+    chat_history = append_message_to_chat_history(
+        chat_history=chat_history,
+        message={"content": response.answer, "role": "assistant"},
+        model=chat_params["model"],
+        model_context_length=chat_params["max_input_tokens"],
+        total_tokens_for_next_generation=chat_params["max_output_tokens"],
+    )
+    return response, chat_history

--- a/core_backend/app/llm_call/process_input.py
+++ b/core_backend/app/llm_call/process_input.py
@@ -316,9 +316,10 @@ def paraphrase_question__before(func: Callable) -> Callable:
             query_id=response.query_id, user_id=query_refined.user_id
         )
 
-        query_refined, response = await _paraphrase_question(
-            query_refined, response, metadata=metadata
-        )
+        if kwargs.get("paraphrase", True):
+            query_refined, response = await _paraphrase_question(
+                query_refined, response, metadata=metadata
+            )
         response = await func(query_refined, response, *args, **kwargs)
 
         return response

--- a/core_backend/app/llm_call/process_input.py
+++ b/core_backend/app/llm_call/process_input.py
@@ -300,6 +300,10 @@ async def _classify_safety(
 def paraphrase_question__before(func: Callable) -> Callable:
     """
     Decorator to paraphrase the question.
+
+    NB: There is no need to paraphrase the search query for the search response if chat
+    is being used since the chat endpoint first constructs the search query using the
+    latest user message and the conversation history from the user assistant chat.
     """
 
     @wraps(func)
@@ -316,7 +320,7 @@ def paraphrase_question__before(func: Callable) -> Callable:
             query_id=response.query_id, user_id=query_refined.user_id
         )
 
-        if kwargs.get("paraphrase", True):
+        if not query_refined.chat_query_params:
             query_refined, response = await _paraphrase_question(
                 query_refined, response, metadata=metadata
             )

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -51,7 +51,6 @@ class AlignScoreData(TypedDict):
 
 async def generate_llm_query_response(
     *,
-    chat_query_params: dict[str, Any],
     metadata: Optional[dict] = None,
     query_refined: QueryRefined,
     response: QueryResponse,
@@ -64,8 +63,6 @@ async def generate_llm_query_response(
 
     Parameters
     ----------
-    chat_query_params
-        The chat query parameters.
     metadata
         Additional metadata to provide to the LLM model.
     query_refined
@@ -79,6 +76,7 @@ async def generate_llm_query_response(
         The updated response object and the chat history.
     """
 
+    chat_query_params = query_refined.chat_query_params or {}
     chat_history = chat_query_params.get("chat_history", [])
     if isinstance(response, QueryResponseError):
         logger.warning("LLM generation skipped due to QueryResponseError.")

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -1,7 +1,6 @@
 """This module contains utility functions related to LLM calls."""
 
 import json
-import re
 from typing import Any, Optional
 
 import redis.asyncio as aioredis
@@ -549,24 +548,3 @@ async def reset_chat_history(
     chat_cache_key = chat_cache_key or f"chatCache:{session_id}"
     await redis_client.delete(chat_cache_key)
     logger.info(f"Finished resetting chat history for session: {session_id}")
-
-
-def strip_tags(*, tag: str, text: str) -> list[str]:
-    """Remove tags from `text`.
-
-    Parameters
-    ----------
-    tag
-        The tag to be stripped.
-    text
-        The input text.
-
-    Returns
-    -------
-    list[str]
-        text: The stripped text.
-    """
-
-    assert tag
-    matches = re.findall(rf"<{tag}>\s*([\s\S]*?)\s*</{tag}>", text)
-    return matches if matches else [text]

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -144,12 +144,14 @@ def _truncate_chat_history(
     index = 1 if chat_history[0]["role"] == "system" else 0
     while remaining_tokens <= 0 and chat_history:
         index = min(len(chat_history) - 1, index)
-        chat_history_tokens -= token_counter(
-            messages=[chat_history.pop(index)], model=model
-        )
+        last_message = chat_history.pop(index)
+        chat_history_tokens -= token_counter(messages=[last_message], model=model)
         remaining_tokens = model_context_length - (
             chat_history_tokens + total_tokens_for_next_generation
         )
+        if remaining_tokens <= 0 and not chat_history:
+            chat_history.append(last_message)
+            break
     if not chat_history:
         logger.warning("Empty chat history after truncating chat messages!")
 

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -154,10 +154,10 @@ def _truncate_chat_history(
         logger.warning("Empty chat history after truncating chat messages!")
 
 
-def append_content_to_chat_history(
+def append_message_content_to_chat_history(
     *,
     chat_history: list[dict[str, str | None]],
-    content: Optional[str] = None,
+    message_content: Optional[str] = None,
     model: str,
     model_context_length: int,
     name: str,
@@ -165,15 +165,15 @@ def append_content_to_chat_history(
     total_tokens_for_next_generation: int,
     truncate_history: bool = True,
 ) -> None:
-    """Append a single message to the chat history.
+    """Append a single message content to the chat history.
 
     Parameters
     ----------
     chat_history
         The chat history buffer.
-    content
-        The contents of the message. `content` is required for all messages, and may be
-        null for assistant messages with function calls.
+    message_content
+        The contents of the message. `message_content` is required for all messages,
+        and may be null for assistant messages with function calls.
     model
         The name of the LLM model.
     model_context_length
@@ -198,9 +198,9 @@ def append_content_to_chat_history(
     assert role in roles, f"Invalid role: {role}. Valid roles are: {roles}"
     if role not in ["assistant", "function"]:
         assert (
-            content is not None
-        ), "`content` can only be `None` for `assistant` and `function` roles."
-    message = {"content": content, "name": name, "role": role}
+            message_content is not None
+        ), "`message_content` can only be `None` for `assistant` and `function` roles."
+    message = {"content": message_content, "name": name, "role": role}
     chat_history.append(message)
     if truncate_history:
         _truncate_chat_history(
@@ -245,9 +245,9 @@ def append_messages_to_chat_history(
         name = message.get("name", None)
         role = message.get("role", None)
         assert name and role
-        append_content_to_chat_history(
+        append_message_content_to_chat_history(
             chat_history=chat_history,
-            content=message.get("content", None),
+            message_content=message.get("content", None),
             model=model,
             model_context_length=model_context_length,
             name=name,
@@ -337,16 +337,16 @@ async def get_chat_response(
         prompt=message_params["prompt"], prompt_kws=prompt_kws
     )
 
-    append_content_to_chat_history(
+    append_message_content_to_chat_history(
         chat_history=chat_history,
-        content=formatted_prompt,
+        message_content=formatted_prompt,
         model=model,
         model_context_length=model_context_length,
         name=session_id,
         role="user",
         total_tokens_for_next_generation=total_tokens_for_next_generation,
     )
-    content = await _ask_llm_async(
+    message_content = await _ask_llm_async(
         litellm_model=LITELLM_MODEL_CHAT,
         llm_generation_params={
             "frequency_penalty": 0.0,
@@ -359,9 +359,9 @@ async def get_chat_response(
         messages=chat_history,
         **kwargs,
     )
-    append_content_to_chat_history(
+    append_message_content_to_chat_history(
         chat_history=chat_history,
-        content=content,
+        message_content=message_content,
         model=model,
         model_context_length=model_context_length,
         name=session_id,
@@ -369,7 +369,7 @@ async def get_chat_response(
         total_tokens_for_next_generation=total_tokens_for_next_generation,
     )
 
-    return content
+    return message_content
 
 
 async def init_chat_history(
@@ -459,9 +459,9 @@ async def init_chat_history(
     chat_params = json.loads(await redis_client.get(chat_params_cache_key))
     assert isinstance(chat_params, dict) and chat_params, f"{chat_params = }"
     chat_history = []
-    append_content_to_chat_history(
+    append_message_content_to_chat_history(
         chat_history=chat_history,
-        content=system_message,
+        message_content=system_message,
         model=chat_params["model"],
         model_context_length=chat_params["max_input_tokens"],
         name=session_id,

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -6,7 +6,6 @@ from typing import Any, Optional
 import redis.asyncio as aioredis
 import requests
 from litellm import acompletion, token_counter
-from termcolor import colored
 
 from ..config import (
     LITELLM_API_KEY,
@@ -501,24 +500,16 @@ def log_chat_history(
         logger.info(f"\n###Chat history: {context}###")
     else:
         logger.info("\n###Chat history###")
-    role_to_color = {
-        "system": "red",
-        "user": "green",
-        "assistant": "blue",
-        "function": "magenta",
-    }
     for message in chat_history:
         role, content = message["role"], message.get("content", None)
-        assert role in role_to_color.keys()
         name = message.get("name", "")
         function_call = message.get("function_call", None)
-        role_color = role_to_color[role]
         if role in ["system", "user"]:
-            logger.info(colored(f"\n{role}:\n{content}\n", role_color))
+            logger.info(f"\n{role}:\n{content}\n")
         elif role == "assistant":
-            logger.info(colored(f"\n{role}:\n{function_call or content}\n", role_color))
+            logger.info(f"\n{role}:\n{function_call or content}\n")
         else:
-            logger.info(colored(f"\n{role}:\n({name}): {content}\n", role_color))
+            logger.info(f"\n{role}:\n({name}): {content}\n")
 
 
 def remove_json_markdown(text: str) -> str:

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -380,7 +380,7 @@ async def init_chat_history(
     reset: bool,
     session_id: str,
     system_message: str = "You are a helpful assistant.",
-) -> tuple[str, str, list[dict[str, str | None]], dict[str, Any], str]:
+) -> tuple[str, str, list[dict[str, str | None]], dict[str, Any]]:
     """Initialize the chat history. Chat history initialization involves initializing
     both the chat parameters **and** the chat history for the session. Chat parameters
     are assumed to be static for a given session.
@@ -406,9 +406,9 @@ async def init_chat_history(
 
     Returns
     -------
-    tuple[str, str, list[dict[str, str]], dict[str, Any], str]
-        The chat cache key, the chat parameters cache key, the chat history, the chat
-        parameters, and the session ID.
+    tuple[str, str, list[dict[str, str]], dict[str, Any]]
+        The chat cache key, the chat parameters cache key, the chat history, and the
+        chat parameters.
     """
 
     # Get the chat history and chat parameters for the session.
@@ -434,13 +434,7 @@ async def init_chat_history(
             f"Chat history and chat parameters are already initialized for session: "
             f"{session_id}. Using existing values."
         )
-        return (
-            chat_cache_key,
-            chat_params_cache_key,
-            chat_history,
-            chat_params,
-            session_id,
-        )
+        return chat_cache_key, chat_params_cache_key, chat_history, chat_params
 
     # Get the chat parameters for the session.
     logger.info(f"Initializing chat parameters for session: {session_id}")
@@ -478,7 +472,7 @@ async def init_chat_history(
         chat_cache_key, json.dumps(chat_history), ex=REDIS_CHAT_CACHE_EXPIRY_TIME
     )
     logger.info(f"Finished initializing chat history for session: {session_id}")
-    return chat_cache_key, chat_params_cache_key, chat_history, chat_params, session_id
+    return chat_cache_key, chat_params_cache_key, chat_history, chat_params
 
 
 def log_chat_history(

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -415,6 +415,10 @@ async def init_chat_history(
     # Get the chat history and chat parameters for the session.
     chat_cache_key = chat_cache_key or f"chatCache:{session_id}"
     chat_params_cache_key = chat_params_cache_key or f"chatParamsCache:{session_id}"
+
+    logger.info(f"Using chat cache ID: {chat_cache_key}")
+    logger.info(f"Using chat params cache ID: {chat_params_cache_key}")
+
     chat_cache_exists = await redis_client.exists(chat_cache_key)
     chat_params_cache_exists = await redis_client.exists(chat_params_cache_key)
     chat_history = (

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -509,12 +509,24 @@ def log_chat_history(
 
 
 def remove_json_markdown(text: str) -> str:
-    """Remove json markdown from text."""
+    """Remove json markdown from text.
 
-    json_str = text.removeprefix("```json").removesuffix("```").strip()
-    json_str = json_str.replace("\{", "{").replace("\}", "}")
+    Parameters
+    ----------
+    text
+        The text containing the json markdown.
 
-    return json_str
+    Returns
+    -------
+    str
+        The text with the json markdown removed.
+    """
+
+    text = text.strip()
+    if text.startswith("```") and text.endswith("```"):
+        text = text.removeprefix("```json").removesuffix("```")
+    text = text.replace("\{", "{").replace("\}", "}")
+    return text.strip()
 
 
 async def reset_chat_history(

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -1,22 +1,65 @@
-from litellm import acompletion
+"""This module contains utility functions related to LLM calls."""
 
-from ..config import LITELLM_API_KEY, LITELLM_ENDPOINT, LITELLM_MODEL_DEFAULT
-from ..utils import setup_logger
+import json
+import re
+from textwrap import dedent
+from typing import Any, Optional
+
+import redis.asyncio as aioredis
+import requests
+from litellm import acompletion, token_counter
+from termcolor import colored
+
+from ..config import (
+    LITELLM_ENDPOINT,
+    LITELLM_MODEL_DEFAULT,
+)
+from ..utils import generate_random_int32, setup_logger
 
 logger = setup_logger("LLM_call")
 
 
 async def _ask_llm_async(
-    user_message: str,
-    system_message: str,
+    user_message: Optional[str] = None,
+    system_message: Optional[str] = None,
+    messages: Optional[list[dict[str, str]]] = None,
     litellm_model: str | None = LITELLM_MODEL_DEFAULT,
     litellm_endpoint: str | None = LITELLM_ENDPOINT,
     metadata: dict | None = None,
     json: bool = False,
+    llm_generation_params: Optional[dict[str, Any]] = None,
 ) -> str:
+    """This is a generic function to send an LLM call to a model provider using
+    `litellm`.
+
+    Parameters
+    ----------
+    user_message
+        The user message. If `None`, then `messages` must be provided.
+    system_message
+        The system message. If `None`, then `messages` must be provided.
+    messages
+        List of dictionaries containing the messages. Each dictionary must contain the
+        keys `content` and `role` at a minimum. If `None`, then `user_message` and
+        `system_message` must be provided.
+    litellm_model
+        The name of the LLM model for the `litellm` proxy server.
+    litellm_endpoint
+        The litellm endpoint.
+    metadata
+        Dictionary containing additional metadata for the `litellm` LLM call.
+    json
+        Specifies whether the response should be returned as a JSON object.
+    llm_generation_params
+        The LLM generation parameters. If `None`, then a default set of parameters will
+        be used.
+
+    Returns
+    -------
+    str
+        The appropriate response from the LLM model.
     """
-    This is a generic function to send an LLM call.
-    """
+
     if metadata is not None:
         metadata["generation_name"] = litellm_model
 
@@ -24,30 +67,535 @@ async def _ask_llm_async(
     if json:
         extra_kwargs["response_format"] = {"type": "json_object"}
 
-    messages = [
-        {
-            "content": system_message,
-            "role": "system",
-        },
-        {
-            "content": user_message,
-            "role": "user",
-        },
-    ]
+    if not messages:
+        assert isinstance(user_message, str) and isinstance(system_message, str)
+        messages = [
+            {
+                "content": system_message,
+                "role": "system",
+            },
+            {
+                "content": user_message,
+                "role": "user",
+            },
+        ]
+    llm_generation_params = llm_generation_params or {
+        "max_tokens": 1024,
+        "temperature": 0,
+    }
+
     logger.info(f"LLM input: 'model': {litellm_model}, 'endpoint': {litellm_endpoint}")
 
     llm_response_raw = await acompletion(
         model=litellm_model,
         messages=messages,
-        temperature=0,
-        max_tokens=1024,
-        api_base=litellm_endpoint,
-        api_key=LITELLM_API_KEY,
+        # api_base=litellm_endpoint,
+        # api_key=LITELLM_API_KEY,
         metadata=metadata,
         **extra_kwargs,
+        **llm_generation_params,
     )
     logger.info(f"LLM output: {llm_response_raw.choices[0].message.content}")
     return llm_response_raw.choices[0].message.content
+
+
+async def _get_chat_response(
+    *,
+    chat_cache_key: str,
+    chat_history: list[dict[str, str]],
+    chat_params: dict[str, Any],
+    original_message_params: dict[str, Any],
+    redis_client: aioredis.Redis,
+    session_id: str,
+    use_zero_shot_cot: bool = False,
+) -> str:
+    """Get the appropriate response and update the chat history. This method also wraps
+    potential Zero-Shot CoT calls.
+
+    Parameters
+    ----------
+    chat_cache_key
+        The chat cache key.
+    chat_history
+        The chat history buffer.
+    chat_params
+        Dictionary containing the chat parameters.
+    original_message_params
+        Dictionary containing the original message parameters.
+    redis_client
+        The Redis client.
+    session_id
+        The session ID for the chat.
+    use_zero_shot_cot
+        Specifies whether to use Zero-Shot CoT to answer the query.
+
+    Returns
+    -------
+    str
+        The appropriate chat response.
+    """
+
+    if use_zero_shot_cot:
+        original_message_params["prompt"] += "\n\nLet's think step by step."
+
+    prompt = format_prompt(
+        prompt=original_message_params["prompt"],
+        prompt_kws=original_message_params.get("prompt_kws", None),
+    )
+    chat_history = append_message_to_chat_history(
+        chat_history=chat_history,
+        content=prompt,
+        model=chat_params["model"],
+        model_context_length=chat_params["max_input_tokens"],
+        name=session_id,
+        role="user",
+        total_tokens_for_next_generation=chat_params["max_output_tokens"],
+    )
+    content = await _ask_llm_async(
+        # litellm_model=LITELLM_MODEL_CHAT,
+        litellm_model="gpt-4o-mini",
+        llm_generation_params={
+            "frequency_penalty": 0.0,
+            "max_tokens": chat_params["max_output_tokens"],
+            "n": 1,
+            "presence_penalty": 0.0,
+            "temperature": 0.7,
+            "top_p": 0.9,
+        },
+        messages=chat_history,
+    )
+    chat_history = append_message_to_chat_history(
+        chat_history=chat_history,
+        message={"content": content, "role": "assistant"},
+        model=chat_params["model"],
+        model_context_length=chat_params["max_input_tokens"],
+        total_tokens_for_next_generation=chat_params["max_output_tokens"],
+    )
+
+    await redis_client.set(chat_cache_key, json.dumps(chat_history))
+    return content
+
+
+def _truncate_chat_history(
+    *,
+    chat_history: list[dict[str, str]],
+    model: str,
+    model_context_length: int,
+    total_tokens_for_next_generation: int,
+) -> None:
+    """Truncate the chat history if necessary. This process removes older messages past
+    the total token limit of the model (but maintains the initial system message if
+    any) and effectively mimics an infinite chat buffer.
+
+    NB: This process does not reset or summarize the chat history. Reset and
+    summarization are done explicitly. Instead, this function should be invoked each
+    time a message is appended to the chat history.
+
+    Parameters
+    ----------
+    chat_history
+        The chat history buffer.
+    model
+        The name of the LLM model.
+    model_context_length
+        The maximum number of tokens allowed for the model. This is the context window
+        length for the model (i.e, maximum number of input + output tokens).
+    total_tokens_for_next_generation
+        The total number of tokens used during ext generation.
+    """
+
+    chat_history_tokens = token_counter(messages=chat_history, model=model)
+    remaining_tokens = model_context_length - (
+        chat_history_tokens + total_tokens_for_next_generation
+    )
+    if remaining_tokens > 0:
+        return
+    logger.warning(
+        f"Truncating chat history for next generation.\n"
+        f"Model context length: {model_context_length}\n"
+        f"Total tokens so far: {chat_history_tokens}\n"
+        f"Total tokens requested for next generation: "
+        f"{total_tokens_for_next_generation}"
+    )
+    index = 1 if chat_history[0].get("role", None) == "system" else 0
+    while remaining_tokens <= 0 and chat_history:
+        index = min(len(chat_history) - 1, index)
+        chat_history_tokens -= token_counter(
+            messages=[chat_history.pop(index)], model=model
+        )
+        remaining_tokens = model_context_length - (
+            chat_history_tokens + total_tokens_for_next_generation
+        )
+    if not chat_history:
+        logger.warning("Empty chat history after truncating chat buffer!")
+
+
+def append_message_to_chat_history(
+    *,
+    chat_history: list[dict[str, str]],
+    content: Optional[str] = "",
+    message: Optional[dict[str, Any]] = None,
+    model: str,
+    model_context_length: int,
+    name: Optional[str] = None,
+    role: Optional[str] = None,
+    total_tokens_for_next_generation: int,
+) -> list[dict[str, str]]:
+    """Append a message to the chat history.
+
+    Parameters
+    ----------
+    chat_history
+        The chat history buffer.
+    content
+        The contents of the message. `content` is required for all messages, and may be
+        null for assistant messages with function calls.
+    message
+        If provided, this dictionary will be appended to the chat history instead of
+        constructing one using the other arguments.
+    model
+        The name of the LLM model.
+    model_context_length
+        The maximum number of tokens allowed for the model. This is the context window
+        length for the model (i.e, maximum number of input + output tokens).
+    name
+        The name of the author of this message. `name` is required if role is
+        `function`, and it should be the name of the function whose response is in
+        the content. May contain a-z, A-Z, 0-9, and underscores, with a maximum length
+        of 64 characters.
+    role
+        The role of the messages author.
+    total_tokens_for_next_generation
+        The total number of tokens during text generation.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        The chat history buffer with the message appended.
+    """
+
+    roles = ["assistant", "function", "system", "user"]
+    if not message:
+        assert name, "`name` is required if `message` is `None`."
+        assert len(name) <= 64, f"`name` must be <= 64 characters: {name}"
+        assert role in roles, f"Invalid role: {role}. Valid roles are: {roles}"
+        message = {"content": content, "name": name, "role": role}
+    chat_history.append(message)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=model,
+        model_context_length=model_context_length,
+        total_tokens_for_next_generation=total_tokens_for_next_generation,
+    )
+    return chat_history
+
+
+def append_system_message_to_chat_history(
+    *,
+    chat_history: Optional[list[dict[str, str]]] = None,
+    model: str,
+    model_context_length: int,
+    session_id: str,
+    total_tokens_for_next_generation: int,
+) -> list[dict[str, str]]:
+    """Append the system message to the chat history.
+
+    Parameters
+    ----------
+    chat_history
+        The chat history buffer.
+    model
+        The name of the LLM model.
+    model_context_length
+        The maximum number of tokens allowed for the model. This is the context window
+        length for the model (i.e, maximum number of input + output tokens).
+    session_id
+        The session ID for the chat.
+    total_tokens_for_next_generation
+        The total number of tokens during text generation.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        The chat history buffer with the system message appended.
+    """
+
+    chat_history = chat_history or []
+    system_message = dedent(
+        """You are an AI assistant designed to help expecting and new mothers with
+        their questions/concerns related to prenatal and newborn care. You interact
+        with mothers via a chat interface.
+
+        For each message from a mother, follow these steps:
+
+        1. Determine the Type of Message:
+            - Follow-up Message: These are messages that build upon the conversation so
+            far and/or seeks more information on a previously discussed
+            question/concern.
+            - Clarification Message: These are messages that seek to clarify something
+            that was previously mentioned in the conversation.
+            - New Message: These are messages that introduce a new topic that was not
+            previously discussed in the conversation.
+
+        2. Obtain More Information to Help Address the Message:
+            - Keep in mind the context given by the conversation history thus far.
+            - Use the conversation history and the Type of Message to formulate a
+            precise query to execute against a vector database that contains
+            information relevant to the current message.
+            - Ensure the query is specific and accurately reflects the mother's
+            information needs.
+            - Use specific keywords that captures the semantic meaning of the mother's
+            information needs.
+
+        Output the vector database query between the tags <Query> and </Query>, without
+        any additional text.
+        """
+    )
+    return append_message_to_chat_history(
+        chat_history=chat_history,
+        content=system_message,
+        model=model,
+        model_context_length=model_context_length,
+        name=session_id,
+        role="system",
+        total_tokens_for_next_generation=total_tokens_for_next_generation,
+    )
+
+
+def format_prompt(
+    *,
+    prompt: str,
+    prompt_kws: Optional[dict[str, Any]] = None,
+    remove_leading_blank_spaces: bool = True,
+) -> str:
+    """Format prompt.
+
+    Parameters
+    ----------
+    prompt
+        String denoting the prompt.
+    prompt_kws
+        If not `None`, then a dictionary containing <key, value> pairs of parameters to
+        use for formatting `prompt`.
+    remove_leading_blank_spaces
+        Specifies whether to remove leading blank spaces from the prompt.
+
+    Returns
+    -------
+    str
+        The formatted prompt.
+    """
+
+    if remove_leading_blank_spaces:
+        prompt = "\n".join([m.lstrip() for m in prompt.split("\n")])
+    return prompt.format(**prompt_kws) if prompt_kws else prompt
+
+
+async def get_chat_response(
+    *,
+    chat_cache_key: Optional[str] = None,
+    chat_params_cache_key: Optional[str] = None,
+    original_message_params: str | dict[str, Any],
+    redis_client: aioredis.Redis,
+    session_id: str,
+    use_zero_shot_cot: bool = False,
+) -> str:
+    """Get the appropriate chat response.
+
+    Parameters
+    ----------
+    chat_cache_key
+        The chat cache key. If `None`, then the key is constructed using the session ID.
+    chat_params_cache_key
+        The chat parameters cache key. If `None`, then the key is constructed using the
+        session ID.
+    original_message_params
+        Dictionary containing the original message parameters or a string containing
+        the message itself. If a dictionary, then the dictionary must contain the key
+        `prompt` and, optionally, the key `prompt_kws`. `prompt` contains the prompt
+        for the LLM. If `prompt_kws` is specified, then it is a dictionary whose
+        <key, value> pairs will be used to string format `prompt`.
+    redis_client
+        The Redis client.
+    session_id
+        The session ID for the chat.
+    use_zero_shot_cot
+        Specifies whether to use Zero-Shot CoT to answer the query.
+
+    Returns
+    -------
+    str
+        The appropriate chat response.
+    """
+
+    (chat_cache_key, chat_params_cache_key, chat_history, session_id) = (
+        await init_chat_history(
+            chat_cache_key=chat_cache_key,
+            chat_params_cache_key=chat_params_cache_key,
+            redis_client=redis_client,
+            reset=False,
+            session_id=session_id,
+        )
+    )
+    assert (
+        isinstance(chat_history, list) and chat_history
+    ), f"Empty chat history for session: {session_id}"
+
+    if isinstance(original_message_params, str):
+        original_message_params = {"prompt": original_message_params}
+    prompt_kws = original_message_params.get("prompt_kws", None)
+    formatted_prompt = format_prompt(
+        prompt=original_message_params["prompt"], prompt_kws=prompt_kws
+    )
+
+    return await _get_chat_response(
+        chat_cache_key=chat_cache_key,
+        chat_history=chat_history,
+        chat_params=json.loads(await redis_client.get(chat_params_cache_key)),
+        original_message_params={"prompt": formatted_prompt},
+        redis_client=redis_client,
+        session_id=session_id,
+        use_zero_shot_cot=use_zero_shot_cot,
+    )
+
+
+async def init_chat_history(
+    *,
+    chat_cache_key: Optional[str] = None,
+    chat_params_cache_key: Optional[str] = None,
+    redis_client: aioredis.Redis,
+    reset: bool,
+    session_id: Optional[str] = None,
+) -> tuple[str, str, list[dict[str, str]], str]:
+    """Initialize the chat history. Chat history initialization involves initializing
+    both the chat parameters **and** the chat history for the session. Thus, chat
+    parameters are assumed to be constant for a given session.
+
+    Parameters
+    ----------
+    chat_cache_key
+        The chat cache key. If `None`, then the key is constructed using the session ID.
+    chat_params_cache_key
+        The chat parameters cache key. If `None`, then the key is constructed using the
+        session ID.
+    redis_client
+        The Redis client.
+    reset
+        Specifies whether to reset the chat history prior to initialization. If `True`,
+        the chat history is completed cleared and reinitialized. If `False` **and** the
+        chat history is previously initialized, then the existing chat history will be
+        used.
+    session_id
+        The session ID for the chat. If `None`, then a randomly generated session ID
+        will be used.
+
+    Returns
+    -------
+    tuple[str, str, list[dict[str, Any]], str]
+        The chat cache key, chat parameters cache key, chat history, and session ID.
+    """
+
+    session_id = session_id or str(generate_random_int32())
+
+    # Get the chat parameters for the session from the LLM model info endpoint or the
+    # Redis cache.
+    chat_params_cache_key = chat_params_cache_key or f"chatParamsCache:{session_id}"
+    chat_params_exists = await redis_client.exists(chat_params_cache_key)
+    if not chat_params_exists:
+        model_info_endpoint = LITELLM_ENDPOINT.rstrip("/") + "/model/info"
+        model_info = requests.get(
+            model_info_endpoint, headers={"accept": "application/json"}
+        ).json()
+        for dict_ in model_info["data"]:
+            if dict_["model_name"] == "chat":
+                chat_params = dict_["model_info"]
+                assert "model" not in chat_params
+                chat_params["model"] = dict_["litellm_params"]["model"]
+                await redis_client.set(chat_params_cache_key, json.dumps(chat_params))
+                break
+
+    # Get the chat history for the session from the Redis cache.
+    chat_cache_key = chat_cache_key or f"chatCache:{session_id}"
+    chat_cache_exists = await redis_client.exists(chat_cache_key)
+    chat_history = (
+        json.loads(await redis_client.get(chat_cache_key)) if chat_cache_exists else []
+    )
+
+    if chat_history and reset is False:
+        logger.info(
+            f"Chat history is already initialized for session: {session_id}. Using "
+            f"existing chat history."
+        )
+        return chat_cache_key, chat_params_cache_key, chat_history, session_id
+
+    logger.info(f"Initializing chat history for session: {session_id}")
+    assert not chat_history or reset is True, (
+        f"Non-empty chat history during initialization: {chat_history}\n"
+        f"Set 'reset' to `True` to initialize chat history."
+    )
+    chat_params = json.loads(await redis_client.get(chat_params_cache_key))
+    assert isinstance(chat_params, dict) and chat_params
+
+    chat_history = append_system_message_to_chat_history(
+        model=chat_params["model"],
+        model_context_length=chat_params["max_input_tokens"],
+        session_id=session_id,
+        total_tokens_for_next_generation=chat_params["max_output_tokens"],
+    )
+    await redis_client.set(session_id, json.dumps(chat_history))
+    logger.info(f"Finished initializing chat history for session: {session_id}")
+    return chat_cache_key, chat_params_cache_key, chat_history, session_id
+
+
+async def log_chat_history(
+    *,
+    chat_cache_key: Optional[str] = None,
+    context: Optional[str] = None,
+    redis_client: aioredis.Redis,
+    session_id: str,
+) -> None:
+    """Log the chat history.
+
+    Parameters
+    ----------
+    chat_cache_key
+        The chat cache key. If `None`, then the key is constructed using the session ID.
+    context
+        Optional string that denotes the context in which the chat history is being
+        logged. Useful to keep track of the call chain execution.
+    redis_client
+        The Redis client.
+    session_id
+        The session ID for the chat.
+    """
+
+    role_to_color = {
+        "system": "red",
+        "user": "green",
+        "assistant": "blue",
+        "function": "magenta",
+    }
+
+    if context:
+        logger.info(f"\n###Chat history for session {session_id}: {context}###")
+    else:
+        logger.info(f"\n###Chat history for session {session_id}###")
+    chat_cache_key = chat_cache_key or f"chatCache:{session_id}"
+    chat_cache_exists = await redis_client.exists(chat_cache_key)
+    chat_history = (
+        json.loads(await redis_client.get(chat_cache_key)) if chat_cache_exists else []
+    )
+    for message in chat_history:
+        role, content = message["role"], message["content"]
+        name = message.get("name", session_id)
+        function_call = message.get("function_call", None)
+        role_color = role_to_color[role]
+        if role in ["system", "user"]:
+            logger.info(colored(f"\n{role}:\n{content}\n", role_color))
+        elif role == "assistant":
+            logger.info(colored(f"\n{role}:\n{function_call or content}\n", role_color))
+        elif role == "function":
+            logger.info(colored(f"\n{role}:\n({name}): {content}\n", role_color))
 
 
 def remove_json_markdown(text: str) -> str:
@@ -57,3 +605,47 @@ def remove_json_markdown(text: str) -> str:
     json_str = json_str.replace("\{", "{").replace("\}", "}")
 
     return json_str
+
+
+async def reset_chat_history(
+    *,
+    chat_cache_key: Optional[str] = None,
+    redis_client: aioredis.Redis,
+    session_id: str,
+) -> None:
+    """Reset the chat history.
+
+    Parameters
+    ----------
+    chat_cache_key
+        The chat cache key. If `None`, then the key is constructed using the session ID.
+    redis_client
+        The Redis client.
+    session_id
+        The session ID for the chat.
+    """
+
+    logger.info(f"Resetting chat history for session: {session_id}")
+    chat_cache_key = chat_cache_key or f"chatCache:{session_id}"
+    await redis_client.delete(chat_cache_key)
+
+
+def strip_tags(*, tag: str, text: str) -> list[str]:
+    """Remove tags from `text`.
+
+    Parameters
+    ----------
+    tag
+        The tag to be stripped.
+    text
+        The input text.
+
+    Returns
+    -------
+    list[str]
+        text: The stripped text.
+    """
+
+    assert tag
+    matches = re.findall(rf"<{tag}>\s*([\s\S]*?)\s*</{tag}>", text)
+    return matches if matches else [text]

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -135,7 +135,7 @@ async def chat(
     returned that includes the search results as well as the details of the failure.
     """
 
-    reset_user_assistant_chat_history = False  # For testing purposes only
+    reset_user_assistant_chat_history = True  # For testing purposes only
     user_query.session_id = 666  # For testing purposes only
 
     # 1.

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -193,7 +193,6 @@ async def search(
             query_refined=user_query_refined_template,
             response=response,
         )
-
     await save_query_response_to_db(user_query_db, response, asession)
     await increment_query_count(
         user_id=user_db.user_id,

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -169,7 +169,7 @@ async def search(
     returned that includes the search results as well as the details of the failure.
     """
 
-    (user_query_db, user_query_refined_template, response_template) = (
+    user_query_db, user_query_refined_template, response_template = (
         await get_user_query_and_response(
             user_id=user_db.user_id,
             user_query=user_query,
@@ -218,10 +218,12 @@ async def search(
 
     if type(response) is QueryResponse:
         return response
+
     if type(response) is QueryResponseError:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST, content=response.model_dump()
         )
+
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"message": "Internal server error"},

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -496,16 +496,12 @@ async def get_generation_response(
         query_id=response.query_id, user_id=query_refined.user_id
     )
 
-    chat_query_params = query_refined.chat_query_params or {}
     response, chat_history = await generate_llm_query_response(
-        chat_query_params=chat_query_params,
-        metadata=metadata,
-        query_refined=query_refined,
-        response=response,
+        query_refined=query_refined, response=response, metadata=metadata
     )
-    if chat_query_params and chat_history:
-        chat_cache_key = chat_query_params["chat_cache_key"]
-        redis_client = chat_query_params["redis_client"]
+    if query_refined.chat_query_params and chat_history:
+        chat_cache_key = query_refined.chat_query_params["chat_cache_key"]
+        redis_client = query_refined.chat_query_params["redis_client"]
         await redis_client.set(
             chat_cache_key, json.dumps(chat_history), ex=REDIS_CHAT_CACHE_EXPIRY_TIME
         )

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -710,7 +710,7 @@ async def init_user_query_and_chat_histories(
     # 2.
     chat_cache_key = f"chatCache:{session_id}"
     chat_params_cache_key = f"chatParamsCache:{session_id}"
-    _, _, user_assistant_chat_history, chat_params, _ = await init_chat_history(
+    _, _, user_assistant_chat_history, chat_params = await init_chat_history(
         chat_cache_key=chat_cache_key,
         chat_params_cache_key=chat_params_cache_key,
         redis_client=redis_client,

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -173,7 +173,7 @@ async def search(
     latest user message and the conversation history from the user assistant chat.
     """
 
-    user_query_db, user_query_refined_template, response_template = (
+    (user_query_db, user_query_refined_template, response_template) = (
         await get_user_query_and_response(
             user_id=user_db.user_id,
             user_query=user_query,
@@ -203,7 +203,9 @@ async def search(
 
     await save_query_response_to_db(user_query_db, response, asession)
     await increment_query_count(
-        user_id=user_db.user_id, contents=response.search_results, asession=asession
+        user_id=user_db.user_id,
+        contents=response.search_results,
+        asession=asession,
     )
     await save_content_for_query_to_db(
         user_id=user_db.user_id,

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -38,7 +38,7 @@ from ..llm_call.process_output import (
     generate_tts__after,
 )
 from ..llm_call.utils import (
-    append_content_to_chat_history,
+    append_message_content_to_chat_history,
     get_chat_response,
     init_chat_history,
 )
@@ -722,9 +722,9 @@ async def init_user_query_and_chat_histories(
 
     # 3.
     search_query_chat_history: list[dict[str, str | None]] = []
-    append_content_to_chat_history(
+    append_message_content_to_chat_history(
         chat_history=search_query_chat_history,
-        content=ChatHistory.system_message_construct_search_query,
+        message_content=ChatHistory.system_message_construct_search_query,
         model=str(chat_params["model"]),
         model_context_length=int(chat_params["max_input_tokens"]),
         name=session_id,

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -58,6 +58,7 @@ class QueryResponse(BaseModel):
     session_id: int | None = Field(None, exclude=True)
     feedback_secret_key: str = Field(..., examples=["secret-key-12345-abcde"])
     llm_response: str | None = Field(None, examples=["Example LLM response"])
+    message_type: Optional[str] = None
 
     search_results: Dict[int, QuerySearchResult] | None = Field(
         examples=[

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -58,7 +58,7 @@ class QueryResponse(BaseModel):
     """
 
     query_id: int = Field(..., examples=[1])
-    session_id: int | None = Field(None, exclude=True)
+    session_id: int | None = Field(None, exclude=False)
     feedback_secret_key: str = Field(..., examples=["secret-key-12345-abcde"])
     llm_response: str | None = Field(None, examples=["Example LLM response"])
     message_type: Optional[str] = None

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -17,6 +17,9 @@ class QueryBase(BaseModel):
     generate_llm_response: bool = Field(False)
     query_metadata: dict = Field({}, examples=[{"some_key": "some_value"}])
     session_id: SkipJsonSchema[int | None] = Field(default=None, exclude=True)
+    chat_query_params: Optional[dict[str, Any]] = Field(
+        default=None, description="Query parameters for chat"
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -60,7 +63,7 @@ class QueryResponse(BaseModel):
     llm_response: str | None = Field(None, examples=["Example LLM response"])
     message_type: Optional[str] = None
 
-    search_results: Dict[int, QuerySearchResult] | None = Field(
+    search_results: dict[int, QuerySearchResult] | None = Field(
         examples=[
             {
                 "0": {

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -5,7 +5,9 @@ import hashlib
 import logging
 import mimetypes
 import os
+import random
 import secrets
+import string
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from logging import Logger
@@ -77,10 +79,20 @@ def verify_password_salted_hash(key: str, stored_hash: str) -> bool:
     return hash_obj.hexdigest() == original_hash
 
 
+def get_random_int32() -> int:
+    """Generate a random 32-bit integer.
+
+    Returns
+    -------
+    int
+        The generated 32-bit integer.
+    """
+
+    return random.randint(-(2**31), 2**31 - 1)
+
+
 def get_random_string(size: int) -> str:
     """Generate a random string of fixed length."""
-    import random
-    import string
 
     return "".join(random.choices(string.ascii_letters + string.digits, k=size))
 

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -6,6 +6,7 @@ import logging
 import mimetypes
 import os
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from logging import Logger
@@ -370,3 +371,18 @@ async def generate_public_url(bucket_name: str, blob_name: str) -> str:
 
     public_url = f"https://storage.googleapis.com/{bucket_name}/{blob_name}"
     return public_url
+
+
+def generate_random_int32() -> int:
+    """Generate a random 32-bit signed integer.
+
+    Returns
+    -------
+    int
+        A random 32-bit signed integer.
+    """
+
+    rand_int = int(uuid.uuid4().int & (1 << 32) - 1)  # Mask to fit in 32 bits
+    if rand_int >= 2**31:  # Convert to signed 32-bit integer
+        rand_int -= 2**32
+    return rand_int

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -6,7 +6,6 @@ import logging
 import mimetypes
 import os
 import secrets
-import uuid
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from logging import Logger
@@ -371,18 +370,3 @@ async def generate_public_url(bucket_name: str, blob_name: str) -> str:
 
     public_url = f"https://storage.googleapis.com/{bucket_name}/{blob_name}"
     return public_url
-
-
-def generate_random_int32() -> int:
-    """Generate a random 32-bit signed integer.
-
-    Returns
-    -------
-    int
-        A random 32-bit signed integer.
-    """
-
-    rand_int = int(uuid.uuid4().int & (1 << 32) - 1)  # Mask to fit in 32 bits
-    if rand_int >= 2**31:  # Convert to signed 32-bit integer
-        rand_int -= 2**32
-    return rand_int

--- a/core_backend/requirements.txt
+++ b/core_backend/requirements.txt
@@ -28,3 +28,4 @@ scikit-learn==1.5.1
 bokeh==3.5.1
 faster-whisper==1.0.3
 sentry-sdk[fastapi]==2.17.0
+termcolor==2.5.0

--- a/core_backend/requirements.txt
+++ b/core_backend/requirements.txt
@@ -28,4 +28,3 @@ scikit-learn==1.5.1
 bokeh==3.5.1
 faster-whisper==1.0.3
 sentry-sdk[fastapi]==2.17.0
-termcolor==2.5.0

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -1,5 +1,4 @@
 import json
-import os
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 
@@ -20,6 +19,7 @@ from core_backend.app.config import (
     LITELLM_ENDPOINT,
     LITELLM_MODEL_EMBEDDING,
     PGVECTOR_VECTOR_SIZE,
+    REDIS_HOST,
 )
 from core_backend.app.contents.models import ContentDB
 from core_backend.app.database import (
@@ -563,7 +563,7 @@ async def redis_client() -> AsyncGenerator[aioredis.Redis, None]:
         Redis client for testing.
     """
 
-    rclient = await aioredis.from_url(os.getenv("REDIS_HOST"), decode_responses=True)
+    rclient = await aioredis.from_url(REDIS_HOST, decode_responses=True)
 
     await rclient.flushdb()
 

--- a/core_backend/tests/api/conftest.py
+++ b/core_backend/tests/api/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 
@@ -19,7 +20,6 @@ from core_backend.app.config import (
     LITELLM_ENDPOINT,
     LITELLM_MODEL_EMBEDDING,
     PGVECTOR_VECTOR_SIZE,
-    REDIS_HOST,
 )
 from core_backend.app.contents.models import ContentDB
 from core_backend.app.database import (
@@ -563,7 +563,7 @@ async def redis_client() -> AsyncGenerator[aioredis.Redis, None]:
         Redis client for testing.
     """
 
-    rclient = await aioredis.from_url(REDIS_HOST, decode_responses=True)
+    rclient = await aioredis.from_url(os.getenv("REDIS_HOST"), decode_responses=True)
 
     await rclient.flushdb()
 

--- a/core_backend/tests/api/test_chat.py
+++ b/core_backend/tests/api/test_chat.py
@@ -1,399 +1,394 @@
-# """This module contains the unit tests related to multi-turn chat for question
-# answering.
-# """
-#
-# import json
-#
-# import pytest
-# from litellm import token_counter
-# from redis import asyncio as aioredis
-#
-# from core_backend.app.config import LITELLM_MODEL_CHAT
-# from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
-# from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
-# from core_backend.app.llm_call.utils import (
-#     _ask_llm_async,
-#     _truncate_chat_history,
-#     append_content_to_chat_history,
-#     init_chat_history,
-#     remove_json_markdown,
-# )
-# from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
-# from core_backend.app.question_answer.schemas import QueryBase
-#
-#
-# @pytest.mark.asyncio
-# async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) -> None:
-#     """Test that the `QueryBase` object returned after initializing the user query
-#     and chat histories contains the expected attributes.
-#
-#     Parameters
-#     ----------
-#     redis_client
-#         The Redis client instance.
-#     """
-#
-#     query_text = "I have a stomachache."
-#     reset_chat_history = False
-#     user_query = await init_user_query_and_chat_histories(
-#         redis_client=redis_client,
-#         reset_chat_history=reset_chat_history,
-#         user_query=QueryBase(query_text=query_text),
-#     )
-#     chat_query_params = user_query.chat_query_params
-#     assert isinstance(chat_query_params, dict) and chat_query_params
-#
-#     chat_history = chat_query_params["chat_history"]
-#     search_query = chat_query_params["search_query"]
-#     session_id = chat_query_params["session_id"]
-#
-#     assert isinstance(chat_history, list) and len(chat_history) == 1
-#     assert isinstance(session_id, str)
-#     assert user_query.generate_llm_response is True
-#     assert user_query.query_text == query_text
-#     assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
-#     assert chat_query_params["message_type"] == "NEW"
-#     assert search_query and search_query != query_text
-#
-#
-# @pytest.mark.asyncio
-# async def test_get_llm_rag_answer_with_chat_history() -> None:
-#     """Test correct chat history for NEW message type."""
-#
-#     session_id = "70284693"
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
-#     chat_params = {
-#         "max_tokens": 8192,
-#         "max_input_tokens": 2097152,
-#         "max_output_tokens": 8192,
-#         "litellm_provider": "vertex_ai-language-models",
-#         "mode": "chat",
-#         "model": "vertex_ai/gemini-1.5-pro",
-#     }
-#     context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
-#     message_type = "NEW"
-#     original_language = IdentifiedLanguage.ENGLISH
-#     question = "i have a stomachache."
-#     _, new_chat_history = await get_llm_rag_answer_with_chat_history(
-#         chat_history=chat_history,
-#         chat_params=chat_params,
-#         context=context,
-#         message_type=message_type,
-#         original_language=original_language,
-#         question=question,
-#         session_id=session_id,
-#     )
-#     assert len(new_chat_history) == 3
-#     assert new_chat_history[0]["role"] == "system"
-#     assert new_chat_history[1]["role"] == "user"
-#     assert new_chat_history[2]["role"] == "assistant"
-#     assert new_chat_history[0]["content"] != "You are a helpful assistant."
-#     assert new_chat_history[1]["content"] == question
-#
-#
-# @pytest.mark.asyncio
-# async def test__ask_llm_async() -> None:
-#     """Test expected operation for the `_ask_llm_async` function."""
-#
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": "123",
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "name": "123",
-#             "role": "user",
-#         },
-#     ]
-#     content = await _ask_llm_async(messages=chat_history)
-#     assert isinstance(content, str) and content
-#
-#     content = await _ask_llm_async(
-#         user_message="What is the meaning of life?",
-#         system_message="You are a helpful assistant.",
-#     )
-#     assert isinstance(content, str) and content
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": "123",
-#             "role": "system",
-#         },
-#         {
-#             "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
-#             "name": "123",
-#             "role": "user",
-#         },
-#     ]
-#     content = await _ask_llm_async(json_=True, messages=chat_history)
-#     content_dict = json.loads(remove_json_markdown(content))
-#     assert isinstance(content_dict, dict) and "answer" in content_dict
-#
-#
-# @pytest.mark.asyncio
-# async def test__ask_llm_async_assertion_error() -> None:
-#     """Test expected operation for the `_ask_llm_async` function when neither
-#     messages nor system message and user message is supplied.
-#     """
-#
-#     with pytest.raises(AssertionError):
-#         _ = await _ask_llm_async()
-#         _ = await _ask_llm_async(system_message="FooBar")
-#         _ = await _ask_llm_async(user_message="FooBar")
-#
-#
-# def test__truncate_chat_history() -> None:
-#     """Test chat history truncation scenarios."""
-#
-#     # Empty chat should return empty chat.
-#     chat_history: list[dict[str, str | None]] = []
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=50,
-#     )
-#     assert len(chat_history) == 0
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=50,
-#     )
-#     assert len(chat_history) == 1
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=150,
-#     )
-#     assert len(chat_history) == 0
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens + 1,
-#         total_tokens_for_next_generation=0,
-#     )
-#     assert chat_history[0]["content"] == "You are a helpful assistant."
-#
-#     chat_history = [
-#         {
-#             "content": "FooBar",
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "role": "user",
-#         },
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens,
-#         total_tokens_for_next_generation=4,
-#     )
-#     assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
-#
-#     chat_history = [
-#         {
-#             "content": "FooBar",
-#             "role": "user",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "role": "user",
-#         },
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens,
-#         total_tokens_for_next_generation=4,
-#     )
-#     assert (
-#         len(chat_history) == 1
-#         and chat_history[0]["content"] == "What is the meaning of life?"
-#     )
-#
-#
-# def test_append_content_to_chat_history() -> None:
-#     """Test appending messages to chat histories."""
-#
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_content_to_chat_history(
-#         chat_history=chat_history,
-#         content="What is the meaning of life?",
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="user",
-#         total_tokens_for_next_generation=50,
-#         truncate_history=True,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "user"
-#         and chat_history[1]["content"] == "What is the meaning of life?"
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_content_to_chat_history(
-#         chat_history=chat_history,
-#         content="What is the meaning of life?",
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="user",
-#         total_tokens_for_next_generation=150,
-#         truncate_history=False,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "user"
-#         and chat_history[1]["content"] == "What is the meaning of life?"
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_content_to_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="assistant",
-#         total_tokens_for_next_generation=150,
-#         truncate_history=False,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "assistant"
-#         and chat_history[1]["content"] is None
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     with pytest.raises(AssertionError):
-#         append_content_to_chat_history(
-#             chat_history=chat_history,
-#             model=LITELLM_MODEL_CHAT,
-#             model_context_length=100,
-#             name="123",
-#             role="user",
-#             total_tokens_for_next_generation=150,
-#             truncate_history=False,
-#         )
-#
-#
-# @pytest.mark.asyncio
-# async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
-#     """Test chat history initialization.
-#
-#     Parameters
-#     ----------
-#     redis_client
-#         The Redis client instance.
-#     """
-#
-#     # First initialization.
-#     session_id = "12345"
-#     (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
-#         await init_chat_history(
-#             redis_client=redis_client, reset=False, session_id=session_id
-#         )
-#     )
-#     assert chat_cache_key == f"chatCache:{session_id}"
-#     assert chat_params_cache_key == f"chatParamsCache:{session_id}"
-#     assert chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
-#     assert isinstance(old_chat_params, dict)
-#     assert all(
-#         x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
-#     )
-#
-#     altered_chat_history = chat_history + [
-#         {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
-#     ]
-#     await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
-#     _, _, new_chat_history, new_chat_params = await init_chat_history(
-#         redis_client=redis_client, reset=False, session_id=session_id
-#     )
-#     assert new_chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "name": session_id,
-#             "role": "user",
-#         },
-#     ]
-#
-#     _, _, reset_chat_history, new_chat_params = await init_chat_history(
-#         redis_client=redis_client, reset=True, session_id=session_id
-#     )
-#     assert reset_chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
+"""This module contains the unit tests related to multi-turn chat for question
+answering.
+"""
+
+import json
+
+import pytest
+from litellm import token_counter
+from redis import asyncio as aioredis
+
+from core_backend.app.config import LITELLM_MODEL_CHAT
+from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
+from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
+from core_backend.app.llm_call.utils import (
+    _ask_llm_async,
+    _truncate_chat_history,
+    append_content_to_chat_history,
+    init_chat_history,
+    remove_json_markdown,
+)
+from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
+from core_backend.app.question_answer.schemas import QueryBase
+
+
+async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) -> None:
+    """Test that the `QueryBase` object returned after initializing the user query
+    and chat histories contains the expected attributes.
+
+    Parameters
+    ----------
+    redis_client
+        The Redis client instance.
+    """
+
+    query_text = "I have a stomachache."
+    reset_chat_history = False
+    user_query = await init_user_query_and_chat_histories(
+        redis_client=redis_client,
+        reset_chat_history=reset_chat_history,
+        user_query=QueryBase(query_text=query_text),
+    )
+    chat_query_params = user_query.chat_query_params
+    assert isinstance(chat_query_params, dict) and chat_query_params
+
+    chat_history = chat_query_params["chat_history"]
+    search_query = chat_query_params["search_query"]
+    session_id = chat_query_params["session_id"]
+
+    assert isinstance(chat_history, list) and len(chat_history) == 1
+    assert isinstance(session_id, str)
+    assert user_query.generate_llm_response is True
+    assert user_query.query_text == query_text
+    assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
+    assert chat_query_params["message_type"] == "NEW"
+    assert search_query and search_query != query_text
+
+
+async def test_get_llm_rag_answer_with_chat_history() -> None:
+    """Test correct chat history for NEW message type."""
+
+    session_id = "70284693"
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]
+    chat_params = {
+        "max_tokens": 8192,
+        "max_input_tokens": 2097152,
+        "max_output_tokens": 8192,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "model": "vertex_ai/gemini-1.5-pro",
+    }
+    context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
+    message_type = "NEW"
+    original_language = IdentifiedLanguage.ENGLISH
+    question = "i have a stomachache."
+    _, new_chat_history = await get_llm_rag_answer_with_chat_history(
+        chat_history=chat_history,
+        chat_params=chat_params,
+        context=context,
+        message_type=message_type,
+        original_language=original_language,
+        question=question,
+        session_id=session_id,
+    )
+    assert len(new_chat_history) == 3
+    assert new_chat_history[0]["role"] == "system"
+    assert new_chat_history[1]["role"] == "user"
+    assert new_chat_history[2]["role"] == "assistant"
+    assert new_chat_history[0]["content"] != "You are a helpful assistant."
+    assert new_chat_history[1]["content"] == question
+
+
+async def test__ask_llm_async() -> None:
+    """Test expected operation for the `_ask_llm_async` function."""
+
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": "123",
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "name": "123",
+            "role": "user",
+        },
+    ]
+    content = await _ask_llm_async(messages=chat_history)
+    assert isinstance(content, str) and content
+
+    content = await _ask_llm_async(
+        user_message="What is the meaning of life?",
+        system_message="You are a helpful assistant.",
+    )
+    assert isinstance(content, str) and content
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": "123",
+            "role": "system",
+        },
+        {
+            "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
+            "name": "123",
+            "role": "user",
+        },
+    ]
+    content = await _ask_llm_async(json_=True, messages=chat_history)
+    content_dict = json.loads(remove_json_markdown(content))
+    assert isinstance(content_dict, dict) and "answer" in content_dict
+
+
+async def test__ask_llm_async_assertion_error() -> None:
+    """Test expected operation for the `_ask_llm_async` function when neither
+    messages nor system message and user message is supplied.
+    """
+
+    with pytest.raises(AssertionError):
+        _ = await _ask_llm_async()
+        _ = await _ask_llm_async(system_message="FooBar")
+        _ = await _ask_llm_async(user_message="FooBar")
+
+
+def test__truncate_chat_history() -> None:
+    """Test chat history truncation scenarios."""
+
+    # Empty chat should return empty chat.
+    chat_history: list[dict[str, str | None]] = []
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 1
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=150,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens + 1,
+        total_tokens_for_next_generation=0,
+    )
+    assert chat_history[0]["content"] == "You are a helpful assistant."
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "user",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert (
+        len(chat_history) == 1
+        and chat_history[0]["content"] == "What is the meaning of life?"
+    )
+
+
+def test_append_content_to_chat_history() -> None:
+    """Test appending messages to chat histories."""
+
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=50,
+        truncate_history=True,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="assistant",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "assistant"
+        and chat_history[1]["content"] is None
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    with pytest.raises(AssertionError):
+        append_content_to_chat_history(
+            chat_history=chat_history,
+            model=LITELLM_MODEL_CHAT,
+            model_context_length=100,
+            name="123",
+            role="user",
+            total_tokens_for_next_generation=150,
+            truncate_history=False,
+        )
+
+
+async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
+    """Test chat history initialization.
+
+    Parameters
+    ----------
+    redis_client
+        The Redis client instance.
+    """
+
+    # First initialization.
+    session_id = "12345"
+    (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
+        await init_chat_history(
+            redis_client=redis_client, reset=False, session_id=session_id
+        )
+    )
+    assert chat_cache_key == f"chatCache:{session_id}"
+    assert chat_params_cache_key == f"chatParamsCache:{session_id}"
+    assert chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]
+    assert isinstance(old_chat_params, dict)
+    assert all(
+        x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
+    )
+
+    altered_chat_history = chat_history + [
+        {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
+    ]
+    await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
+    _, _, new_chat_history, new_chat_params = await init_chat_history(
+        redis_client=redis_client, reset=False, session_id=session_id
+    )
+    assert new_chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "name": session_id,
+            "role": "user",
+        },
+    ]
+
+    _, _, reset_chat_history, new_chat_params = await init_chat_history(
+        redis_client=redis_client, reset=True, session_id=session_id
+    )
+    assert reset_chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]

--- a/core_backend/tests/api/test_chat.py
+++ b/core_backend/tests/api/test_chat.py
@@ -2,22 +2,11 @@
 answering.
 """
 
-import json
 
-import pytest
-from litellm import token_counter
+from unittest.mock import AsyncMock, patch
+
 from redis import asyncio as aioredis
 
-from core_backend.app.config import LITELLM_MODEL_CHAT
-from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
-from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
-from core_backend.app.llm_call.utils import (
-    _ask_llm_async,
-    _truncate_chat_history,
-    append_content_to_chat_history,
-    init_chat_history,
-    remove_json_markdown,
-)
 from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
 from core_backend.app.question_answer.schemas import QueryBase
 
@@ -34,361 +23,395 @@ async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) 
 
     query_text = "I have a stomachache."
     reset_chat_history = False
-    user_query = await init_user_query_and_chat_histories(
-        redis_client=redis_client,
-        reset_chat_history=reset_chat_history,
-        user_query=QueryBase(query_text=query_text),
+    user_query_object = QueryBase(query_text=query_text)
+    assert user_query_object.generate_llm_response is False
+    assert user_query_object.session_id is None
+
+    # Mock return values
+    mock_init_chat_history_return_value = (
+        None,
+        None,
+        [{"role": "system", "content": "You are a helpful assistant."}],
+        {"model": "test-model", "max_input_tokens": 1000, "max_output_tokens": 200},
     )
-    chat_query_params = user_query.chat_query_params
-    assert isinstance(chat_query_params, dict) and chat_query_params
-
-    chat_history = chat_query_params["chat_history"]
-    search_query = chat_query_params["search_query"]
-    session_id = chat_query_params["session_id"]
-
-    assert isinstance(chat_history, list) and len(chat_history) == 1
-    assert isinstance(session_id, str)
-    assert user_query.generate_llm_response is True
-    assert user_query.query_text == query_text
-    assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
-    assert chat_query_params["message_type"] == "NEW"
-    assert search_query and search_query != query_text
-
-
-async def test_get_llm_rag_answer_with_chat_history() -> None:
-    """Test correct chat history for NEW message type."""
-
-    session_id = "70284693"
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
-    chat_params = {
-        "max_tokens": 8192,
-        "max_input_tokens": 2097152,
-        "max_output_tokens": 8192,
-        "litellm_provider": "vertex_ai-language-models",
-        "mode": "chat",
-        "model": "vertex_ai/gemini-1.5-pro",
-    }
-    context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
-    message_type = "NEW"
-    original_language = IdentifiedLanguage.ENGLISH
-    question = "i have a stomachache."
-    _, new_chat_history = await get_llm_rag_answer_with_chat_history(
-        chat_history=chat_history,
-        chat_params=chat_params,
-        context=context,
-        message_type=message_type,
-        original_language=original_language,
-        question=question,
-        session_id=session_id,
-    )
-    assert len(new_chat_history) == 3
-    assert new_chat_history[0]["role"] == "system"
-    assert new_chat_history[1]["role"] == "user"
-    assert new_chat_history[2]["role"] == "assistant"
-    assert new_chat_history[0]["content"] != "You are a helpful assistant."
-    assert new_chat_history[1]["content"] == question
-
-
-async def test__ask_llm_async() -> None:
-    """Test expected operation for the `_ask_llm_async` function."""
-
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": "123",
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "name": "123",
-            "role": "user",
-        },
-    ]
-    content = await _ask_llm_async(messages=chat_history)
-    assert isinstance(content, str) and content
-
-    content = await _ask_llm_async(
-        user_message="What is the meaning of life?",
-        system_message="You are a helpful assistant.",
-    )
-    assert isinstance(content, str) and content
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": "123",
-            "role": "system",
-        },
-        {
-            "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
-            "name": "123",
-            "role": "user",
-        },
-    ]
-    content = await _ask_llm_async(json_=True, messages=chat_history)
-    content_dict = json.loads(remove_json_markdown(content))
-    assert isinstance(content_dict, dict) and "answer" in content_dict
-
-
-async def test__ask_llm_async_assertion_error() -> None:
-    """Test expected operation for the `_ask_llm_async` function when neither
-    messages nor system message and user message is supplied.
-    """
-
-    with pytest.raises(AssertionError):
-        _ = await _ask_llm_async()
-        _ = await _ask_llm_async(system_message="FooBar")
-        _ = await _ask_llm_async(user_message="FooBar")
-
-
-def test__truncate_chat_history() -> None:
-    """Test chat history truncation scenarios."""
-
-    # Empty chat should return empty chat.
-    chat_history: list[dict[str, str | None]] = []
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=50,
-    )
-    assert len(chat_history) == 0
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=50,
-    )
-    assert len(chat_history) == 1
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=150,
-    )
-    assert len(chat_history) == 0
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens + 1,
-        total_tokens_for_next_generation=0,
-    )
-    assert chat_history[0]["content"] == "You are a helpful assistant."
-
-    chat_history = [
-        {
-            "content": "FooBar",
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "role": "user",
-        },
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens,
-        total_tokens_for_next_generation=4,
-    )
-    assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
-
-    chat_history = [
-        {
-            "content": "FooBar",
-            "role": "user",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "role": "user",
-        },
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens,
-        total_tokens_for_next_generation=4,
-    )
-    assert (
-        len(chat_history) == 1
-        and chat_history[0]["content"] == "What is the meaning of life?"
+    mock_search_query_json_str = (
+        '{"message_type": "NEW", "query": "stomachache and possible remedies"}'
     )
 
+    # Patching the functions
+    with (
+        patch(
+            "core_backend.app.question_answer.routers.init_chat_history",
+            new_callable=AsyncMock,
+        ) as mock_init_chat_history,
+        patch(
+            "core_backend.app.question_answer.routers.get_chat_response",
+            new_callable=AsyncMock,
+        ) as mock_get_chat_response,
+    ):
+        mock_init_chat_history.return_value = mock_init_chat_history_return_value
+        mock_get_chat_response.return_value = mock_search_query_json_str
 
-def test_append_content_to_chat_history() -> None:
-    """Test appending messages to chat histories."""
-
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        content="What is the meaning of life?",
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="user",
-        total_tokens_for_next_generation=50,
-        truncate_history=True,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "user"
-        and chat_history[1]["content"] == "What is the meaning of life?"
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        content="What is the meaning of life?",
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="user",
-        total_tokens_for_next_generation=150,
-        truncate_history=False,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "user"
-        and chat_history[1]["content"] == "What is the meaning of life?"
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="assistant",
-        total_tokens_for_next_generation=150,
-        truncate_history=False,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "assistant"
-        and chat_history[1]["content"] is None
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    with pytest.raises(AssertionError):
-        append_content_to_chat_history(
-            chat_history=chat_history,
-            model=LITELLM_MODEL_CHAT,
-            model_context_length=100,
-            name="123",
-            role="user",
-            total_tokens_for_next_generation=150,
-            truncate_history=False,
+        # Call the function under test
+        user_query = await init_user_query_and_chat_histories(
+            redis_client=redis_client,
+            reset_chat_history=reset_chat_history,
+            user_query=user_query_object,
         )
+        chat_query_params = user_query.chat_query_params
 
-
-async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
-    """Test chat history initialization.
-
-    Parameters
-    ----------
-    redis_client
-        The Redis client instance.
-    """
-
-    # First initialization.
-    session_id = "12345"
-    (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
-        await init_chat_history(
-            redis_client=redis_client, reset=False, session_id=session_id
+        # Assertions
+        mock_init_chat_history.assert_called_once_with(
+            chat_cache_key=f"chatCache:{user_query.session_id}",
+            chat_params_cache_key=f"chatParamsCache:{user_query.session_id}",
+            redis_client=redis_client,
+            reset=reset_chat_history,
+            session_id=str(user_query.session_id),
         )
-    )
-    assert chat_cache_key == f"chatCache:{session_id}"
-    assert chat_params_cache_key == f"chatParamsCache:{session_id}"
-    assert chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
-    assert isinstance(old_chat_params, dict)
-    assert all(
-        x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
-    )
+        mock_get_chat_response.assert_called_once()
+        assert user_query.generate_llm_response is True
+        assert user_query.query_text == query_text
+        assert (
+            chat_query_params["chat_cache_key"] == f"chatCache:{user_query.session_id}"
+        )
+        assert chat_query_params["message_type"] == "NEW"
+        assert chat_query_params["search_query"] == "stomachache and possible remedies"
 
-    altered_chat_history = chat_history + [
-        {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
-    ]
-    await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
-    _, _, new_chat_history, new_chat_params = await init_chat_history(
-        redis_client=redis_client, reset=False, session_id=session_id
-    )
-    assert new_chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "name": session_id,
-            "role": "user",
-        },
-    ]
 
-    _, _, reset_chat_history, new_chat_params = await init_chat_history(
-        redis_client=redis_client, reset=True, session_id=session_id
-    )
-    assert reset_chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
+# async def test_get_llm_rag_answer_with_chat_history() -> None:
+#     """Test correct chat history for NEW message type."""
+#
+#     session_id = "70284693"
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]
+#     chat_params = {
+#         "max_tokens": 8192,
+#         "max_input_tokens": 2097152,
+#         "max_output_tokens": 8192,
+#         "litellm_provider": "vertex_ai-language-models",
+#         "mode": "chat",
+#         "model": "vertex_ai/gemini-1.5-pro",
+#     }
+#     context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
+#     message_type = "NEW"
+#     original_language = IdentifiedLanguage.ENGLISH
+#     question = "i have a stomachache."
+#     _, new_chat_history = await get_llm_rag_answer_with_chat_history(
+#         chat_history=chat_history,
+#         chat_params=chat_params,
+#         context=context,
+#         message_type=message_type,
+#         original_language=original_language,
+#         question=question,
+#         session_id=session_id,
+#     )
+#     assert len(new_chat_history) == 3
+#     assert new_chat_history[0]["role"] == "system"
+#     assert new_chat_history[1]["role"] == "user"
+#     assert new_chat_history[2]["role"] == "assistant"
+#     assert new_chat_history[0]["content"] != "You are a helpful assistant."
+#     assert new_chat_history[1]["content"] == question
+#
+#
+# async def test__ask_llm_async() -> None:
+#     """Test expected operation for the `_ask_llm_async` function."""
+#
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": "123",
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "name": "123",
+#             "role": "user",
+#         },
+#     ]
+#     content = await _ask_llm_async(messages=chat_history)
+#     assert isinstance(content, str) and content
+#
+#     content = await _ask_llm_async(
+#         user_message="What is the meaning of life?",
+#         system_message="You are a helpful assistant.",
+#     )
+#     assert isinstance(content, str) and content
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": "123",
+#             "role": "system",
+#         },
+#         {
+#             "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
+#             "name": "123",
+#             "role": "user",
+#         },
+#     ]
+#     content = await _ask_llm_async(json_=True, messages=chat_history)
+#     content_dict = json.loads(remove_json_markdown(content))
+#     assert isinstance(content_dict, dict) and "answer" in content_dict
+#
+#
+# async def test__ask_llm_async_assertion_error() -> None:
+#     """Test expected operation for the `_ask_llm_async` function when neither
+#     messages nor system message and user message is supplied.
+#     """
+#
+#     with pytest.raises(AssertionError):
+#         _ = await _ask_llm_async()
+#         _ = await _ask_llm_async(system_message="FooBar")
+#         _ = await _ask_llm_async(user_message="FooBar")
+#
+#
+# def test__truncate_chat_history() -> None:
+#     """Test chat history truncation scenarios."""
+#
+#     # Empty chat should return empty chat.
+#     chat_history: list[dict[str, str | None]] = []
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=50,
+#     )
+#     assert len(chat_history) == 0
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=50,
+#     )
+#     assert len(chat_history) == 1
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=150,
+#     )
+#     assert len(chat_history) == 0
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens + 1,
+#         total_tokens_for_next_generation=0,
+#     )
+#     assert chat_history[0]["content"] == "You are a helpful assistant."
+#
+#     chat_history = [
+#         {
+#             "content": "FooBar",
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "role": "user",
+#         },
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens,
+#         total_tokens_for_next_generation=4,
+#     )
+#     assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
+#
+#     chat_history = [
+#         {
+#             "content": "FooBar",
+#             "role": "user",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "role": "user",
+#         },
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens,
+#         total_tokens_for_next_generation=4,
+#     )
+#     assert (
+#         len(chat_history) == 1
+#         and chat_history[0]["content"] == "What is the meaning of life?"
+#     )
+#
+#
+# def test_append_message_content_to_chat_history() -> None:
+#     """Test appending messages to chat histories."""
+#
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_message_content_to_chat_history(
+#         chat_history=chat_history,
+#         message_content="What is the meaning of life?",
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="user",
+#         total_tokens_for_next_generation=50,
+#         truncate_history=True,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "user"
+#         and chat_history[1]["content"] == "What is the meaning of life?"
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_message_content_to_chat_history(
+#         chat_history=chat_history,
+#         message_content="What is the meaning of life?",
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="user",
+#         total_tokens_for_next_generation=150,
+#         truncate_history=False,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "user"
+#         and chat_history[1]["content"] == "What is the meaning of life?"
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_message_content_to_chat_history(
+#         chat_history=chat_history,
+#         message_content=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="assistant",
+#         total_tokens_for_next_generation=150,
+#         truncate_history=False,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "assistant"
+#         and chat_history[1]["content"] is None
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     with pytest.raises(AssertionError):
+#         append_message_content_to_chat_history(
+#             chat_history=chat_history,
+#             model=LITELLM_MODEL_CHAT,
+#             model_context_length=100,
+#             name="123",
+#             role="user",
+#             total_tokens_for_next_generation=150,
+#             truncate_history=False,
+#         )
+#
+#
+# async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
+#     """Test chat history initialization.
+#
+#     Parameters
+#     ----------
+#     redis_client
+#         The Redis client instance.
+#     """
+#
+#     # First initialization.
+#     session_id = "12345"
+#     (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
+#         await init_chat_history(
+#             redis_client=redis_client, reset=False, session_id=session_id
+#         )
+#     )
+#     assert chat_cache_key == f"chatCache:{session_id}"
+#     assert chat_params_cache_key == f"chatParamsCache:{session_id}"
+#     assert chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]
+#     assert isinstance(old_chat_params, dict)
+#     assert all(
+#         x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
+#     )
+#
+#     altered_chat_history = chat_history + [
+#         {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
+#     ]
+#     await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
+#     _, _, new_chat_history, new_chat_params = await init_chat_history(
+#         redis_client=redis_client, reset=False, session_id=session_id
+#     )
+#     assert new_chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "name": session_id,
+#             "role": "user",
+#         },
+#     ]
+#
+#     _, _, reset_chat_history, new_chat_params = await init_chat_history(
+#         redis_client=redis_client, reset=True, session_id=session_id
+#     )
+#     assert reset_chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]

--- a/core_backend/tests/api/test_chat.py
+++ b/core_backend/tests/api/test_chat.py
@@ -2,11 +2,20 @@
 answering.
 """
 
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from unittest.mock import AsyncMock, patch
-
+import pytest
+from litellm import token_counter
 from redis import asyncio as aioredis
 
+from core_backend.app.config import LITELLM_MODEL_CHAT
+from core_backend.app.llm_call.utils import (
+    _ask_llm_async,
+    _truncate_chat_history,
+    append_message_content_to_chat_history,
+    init_chat_history,
+)
 from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
 from core_backend.app.question_answer.schemas import QueryBase
 
@@ -59,6 +68,7 @@ async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) 
             user_query=user_query_object,
         )
         chat_query_params = user_query.chat_query_params
+        assert isinstance(chat_query_params, dict)
 
         # Assertions
         mock_init_chat_history.assert_called_once_with(
@@ -78,340 +88,318 @@ async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) 
         assert chat_query_params["search_query"] == "stomachache and possible remedies"
 
 
-# async def test_get_llm_rag_answer_with_chat_history() -> None:
-#     """Test correct chat history for NEW message type."""
-#
-#     session_id = "70284693"
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
-#     chat_params = {
-#         "max_tokens": 8192,
-#         "max_input_tokens": 2097152,
-#         "max_output_tokens": 8192,
-#         "litellm_provider": "vertex_ai-language-models",
-#         "mode": "chat",
-#         "model": "vertex_ai/gemini-1.5-pro",
-#     }
-#     context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
-#     message_type = "NEW"
-#     original_language = IdentifiedLanguage.ENGLISH
-#     question = "i have a stomachache."
-#     _, new_chat_history = await get_llm_rag_answer_with_chat_history(
-#         chat_history=chat_history,
-#         chat_params=chat_params,
-#         context=context,
-#         message_type=message_type,
-#         original_language=original_language,
-#         question=question,
-#         session_id=session_id,
-#     )
-#     assert len(new_chat_history) == 3
-#     assert new_chat_history[0]["role"] == "system"
-#     assert new_chat_history[1]["role"] == "user"
-#     assert new_chat_history[2]["role"] == "assistant"
-#     assert new_chat_history[0]["content"] != "You are a helpful assistant."
-#     assert new_chat_history[1]["content"] == question
-#
-#
-# async def test__ask_llm_async() -> None:
-#     """Test expected operation for the `_ask_llm_async` function."""
-#
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": "123",
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "name": "123",
-#             "role": "user",
-#         },
-#     ]
-#     content = await _ask_llm_async(messages=chat_history)
-#     assert isinstance(content, str) and content
-#
-#     content = await _ask_llm_async(
-#         user_message="What is the meaning of life?",
-#         system_message="You are a helpful assistant.",
-#     )
-#     assert isinstance(content, str) and content
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": "123",
-#             "role": "system",
-#         },
-#         {
-#             "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
-#             "name": "123",
-#             "role": "user",
-#         },
-#     ]
-#     content = await _ask_llm_async(json_=True, messages=chat_history)
-#     content_dict = json.loads(remove_json_markdown(content))
-#     assert isinstance(content_dict, dict) and "answer" in content_dict
-#
-#
-# async def test__ask_llm_async_assertion_error() -> None:
-#     """Test expected operation for the `_ask_llm_async` function when neither
-#     messages nor system message and user message is supplied.
-#     """
-#
-#     with pytest.raises(AssertionError):
-#         _ = await _ask_llm_async()
-#         _ = await _ask_llm_async(system_message="FooBar")
-#         _ = await _ask_llm_async(user_message="FooBar")
-#
-#
-# def test__truncate_chat_history() -> None:
-#     """Test chat history truncation scenarios."""
-#
-#     # Empty chat should return empty chat.
-#     chat_history: list[dict[str, str | None]] = []
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=50,
-#     )
-#     assert len(chat_history) == 0
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=50,
-#     )
-#     assert len(chat_history) == 1
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         total_tokens_for_next_generation=150,
-#     )
-#     assert len(chat_history) == 0
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens + 1,
-#         total_tokens_for_next_generation=0,
-#     )
-#     assert chat_history[0]["content"] == "You are a helpful assistant."
-#
-#     chat_history = [
-#         {
-#             "content": "FooBar",
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "role": "user",
-#         },
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens,
-#         total_tokens_for_next_generation=4,
-#     )
-#     assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
-#
-#     chat_history = [
-#         {
-#             "content": "FooBar",
-#             "role": "user",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "role": "user",
-#         },
-#     ]
-#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-#     _truncate_chat_history(
-#         chat_history=chat_history,
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=chat_history_tokens,
-#         total_tokens_for_next_generation=4,
-#     )
-#     assert (
-#         len(chat_history) == 1
-#         and chat_history[0]["content"] == "What is the meaning of life?"
-#     )
-#
-#
-# def test_append_message_content_to_chat_history() -> None:
-#     """Test appending messages to chat histories."""
-#
-#     chat_history: list[dict[str, str | None]] = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_message_content_to_chat_history(
-#         chat_history=chat_history,
-#         message_content="What is the meaning of life?",
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="user",
-#         total_tokens_for_next_generation=50,
-#         truncate_history=True,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "user"
-#         and chat_history[1]["content"] == "What is the meaning of life?"
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_message_content_to_chat_history(
-#         chat_history=chat_history,
-#         message_content="What is the meaning of life?",
-#         model=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="user",
-#         total_tokens_for_next_generation=150,
-#         truncate_history=False,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "user"
-#         and chat_history[1]["content"] == "What is the meaning of life?"
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     append_message_content_to_chat_history(
-#         chat_history=chat_history,
-#         message_content=LITELLM_MODEL_CHAT,
-#         model_context_length=100,
-#         name="123",
-#         role="assistant",
-#         total_tokens_for_next_generation=150,
-#         truncate_history=False,
-#     )
-#     assert (
-#         len(chat_history) == 2
-#         and chat_history[1]["role"] == "assistant"
-#         and chat_history[1]["content"] is None
-#     )
-#
-#     chat_history = [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "role": "system",
-#         }
-#     ]
-#     with pytest.raises(AssertionError):
-#         append_message_content_to_chat_history(
-#             chat_history=chat_history,
-#             model=LITELLM_MODEL_CHAT,
-#             model_context_length=100,
-#             name="123",
-#             role="user",
-#             total_tokens_for_next_generation=150,
-#             truncate_history=False,
-#         )
-#
-#
-# async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
-#     """Test chat history initialization.
-#
-#     Parameters
-#     ----------
-#     redis_client
-#         The Redis client instance.
-#     """
-#
-#     # First initialization.
-#     session_id = "12345"
-#     (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
-#         await init_chat_history(
-#             redis_client=redis_client, reset=False, session_id=session_id
-#         )
-#     )
-#     assert chat_cache_key == f"chatCache:{session_id}"
-#     assert chat_params_cache_key == f"chatParamsCache:{session_id}"
-#     assert chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
-#     assert isinstance(old_chat_params, dict)
-#     assert all(
-#         x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
-#     )
-#
-#     altered_chat_history = chat_history + [
-#         {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
-#     ]
-#     await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
-#     _, _, new_chat_history, new_chat_params = await init_chat_history(
-#         redis_client=redis_client, reset=False, session_id=session_id
-#     )
-#     assert new_chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         },
-#         {
-#             "content": "What is the meaning of life?",
-#             "name": session_id,
-#             "role": "user",
-#         },
-#     ]
-#
-#     _, _, reset_chat_history, new_chat_params = await init_chat_history(
-#         redis_client=redis_client, reset=True, session_id=session_id
-#     )
-#     assert reset_chat_history == [
-#         {
-#             "content": "You are a helpful assistant.",
-#             "name": session_id,
-#             "role": "system",
-#         }
-#     ]
+async def test__ask_llm_async() -> None:
+    """Test expected operation for the `_ask_llm_async` function when neither
+    messages nor system message and user message is supplied.
+    """
+
+    # Mock return values
+    mock_object = MagicMock()
+    mock_object.llm_response_raw.choices = [MagicMock()]
+    mock_object.llm_response_raw.choices[0].message.content = "FooBar"
+    mock_acompletion_return_value = mock_object
+
+    # Patching the functions
+    with (
+        patch(
+            "core_backend.app.llm_call.utils.acompletion", new_callable=AsyncMock
+        ) as mock_acompletion,
+    ):
+        mock_acompletion.return_value = mock_acompletion_return_value
+
+        # Call the function under test
+        with pytest.raises(AssertionError):
+            _ = await _ask_llm_async()
+            _ = await _ask_llm_async(system_message="FooBar")
+            _ = await _ask_llm_async(user_message="FooBar")
+
+
+def test__truncate_chat_history() -> None:
+    """Test chat history truncation scenarios."""
+
+    # Empty chat should return empty chat.
+    chat_history: list[dict[str, str | None]] = []
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 1
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=150,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens + 1,
+        total_tokens_for_next_generation=0,
+    )
+    assert chat_history[0]["content"] == "You are a helpful assistant."
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "user",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert (
+        len(chat_history) == 1
+        and chat_history[0]["content"] == "What is the meaning of life?"
+    )
+
+
+def test_append_message_content_to_chat_history() -> None:
+    """Test appending messages to chat histories."""
+
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_message_content_to_chat_history(
+        chat_history=chat_history,
+        message_content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=50,
+        truncate_history=True,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_message_content_to_chat_history(
+        chat_history=chat_history,
+        message_content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_message_content_to_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="assistant",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "assistant"
+        and chat_history[1]["content"] is None
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    with pytest.raises(AssertionError):
+        append_message_content_to_chat_history(
+            chat_history=chat_history,
+            model=LITELLM_MODEL_CHAT,
+            model_context_length=100,
+            name="123",
+            role="user",
+            total_tokens_for_next_generation=150,
+            truncate_history=False,
+        )
+
+
+async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
+    """Test chat history initialization.
+
+    Parameters
+    ----------
+    redis_client
+        The Redis client instance.
+    """
+
+    # Mock return values
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "model_name": "chat",
+                "model_info": {
+                    "max_input_tokens": 1000,
+                    "max_output_tokens": 200,
+                },
+                "litellm_params": {
+                    "model": "test-model",
+                },
+            },
+        ],
+    }
+
+    # Patching the functions
+    with patch(
+        "core_backend.app.llm_call.utils.requests.get", return_value=mock_response
+    ):
+        # Call the function under test
+        session_id = "12345"
+        (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
+            await init_chat_history(
+                redis_client=redis_client, reset=False, session_id=session_id
+            )
+        )
+        assert chat_cache_key == f"chatCache:{session_id}"
+        assert chat_params_cache_key == f"chatParamsCache:{session_id}"
+        assert chat_history == [
+            {
+                "content": "You are a helpful assistant.",
+                "name": session_id,
+                "role": "system",
+            }
+        ]
+        assert isinstance(old_chat_params, dict)
+        assert all(
+            x in old_chat_params
+            for x in ["max_input_tokens", "max_output_tokens", "model"]
+        )
+
+        altered_chat_history = chat_history + [
+            {
+                "content": "What is the meaning of life?",
+                "name": session_id,
+                "role": "user",
+            }
+        ]
+        await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
+        _, _, new_chat_history, new_chat_params = await init_chat_history(
+            redis_client=redis_client, reset=False, session_id=session_id
+        )
+        assert new_chat_history == [
+            {
+                "content": "You are a helpful assistant.",
+                "name": session_id,
+                "role": "system",
+            },
+            {
+                "content": "What is the meaning of life?",
+                "name": session_id,
+                "role": "user",
+            },
+        ]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "model_name": "chat",
+                "model_info": {
+                    "max_input_tokens": 1000,
+                    "max_output_tokens": 200,
+                },
+                "litellm_params": {
+                    "model": "test-model",
+                },
+            },
+        ],
+    }
+    with patch(
+        "core_backend.app.llm_call.utils.requests.get", return_value=mock_response
+    ):
+        _, _, reset_chat_history, new_chat_params = await init_chat_history(
+            redis_client=redis_client, reset=True, session_id=session_id
+        )
+        assert reset_chat_history == [
+            {
+                "content": "You are a helpful assistant.",
+                "name": session_id,
+                "role": "system",
+            }
+        ]

--- a/core_backend/tests/api/test_chat.py
+++ b/core_backend/tests/api/test_chat.py
@@ -1,0 +1,399 @@
+"""This module contains the unit tests related to multi-turn chat for question
+answering.
+"""
+
+import json
+
+import pytest
+from litellm import token_counter
+from redis import asyncio as aioredis
+
+from core_backend.app.config import LITELLM_MODEL_CHAT
+from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
+from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
+from core_backend.app.llm_call.utils import (
+    _ask_llm_async,
+    _truncate_chat_history,
+    append_content_to_chat_history,
+    init_chat_history,
+    remove_json_markdown,
+)
+from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
+from core_backend.app.question_answer.schemas import QueryBase
+
+
+@pytest.mark.asyncio
+async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) -> None:
+    """Test that the `QueryBase` object returned after initializing the user query
+    and chat histories contains the expected attributes.
+
+    Parameters
+    ----------
+    redis_client
+        The Redis client instance.
+    """
+
+    query_text = "I have a stomachache."
+    reset_chat_history = False
+    user_query = await init_user_query_and_chat_histories(
+        redis_client=redis_client,
+        reset_chat_history=reset_chat_history,
+        user_query=QueryBase(query_text=query_text),
+    )
+    chat_query_params = user_query.chat_query_params
+    assert isinstance(chat_query_params, dict) and chat_query_params
+
+    chat_history = chat_query_params["chat_history"]
+    search_query = chat_query_params["search_query"]
+    session_id = chat_query_params["session_id"]
+
+    assert isinstance(chat_history, list) and len(chat_history) == 1
+    assert isinstance(session_id, str)
+    assert user_query.generate_llm_response is True
+    assert user_query.query_text == query_text
+    assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
+    assert chat_query_params["message_type"] == "NEW"
+    assert search_query and search_query != query_text
+
+
+@pytest.mark.asyncio
+async def test_get_llm_rag_answer_with_chat_history() -> None:
+    """Test correct chat history for NEW message type."""
+
+    session_id = "70284693"
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]
+    chat_params = {
+        "max_tokens": 8192,
+        "max_input_tokens": 2097152,
+        "max_output_tokens": 8192,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "model": "vertex_ai/gemini-1.5-pro",
+    }
+    context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
+    message_type = "NEW"
+    original_language = IdentifiedLanguage.ENGLISH
+    question = "i have a stomachache."
+    _, new_chat_history = await get_llm_rag_answer_with_chat_history(
+        chat_history=chat_history,
+        chat_params=chat_params,
+        context=context,
+        message_type=message_type,
+        original_language=original_language,
+        question=question,
+        session_id=session_id,
+    )
+    assert len(new_chat_history) == 3
+    assert new_chat_history[0]["role"] == "system"
+    assert new_chat_history[1]["role"] == "user"
+    assert new_chat_history[2]["role"] == "assistant"
+    assert new_chat_history[0]["content"] != "You are a helpful assistant."
+    assert new_chat_history[1]["content"] == question
+
+
+@pytest.mark.asyncio
+async def test__ask_llm_async() -> None:
+    """Test expected operation for the `_ask_llm_async` function."""
+
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": "123",
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "name": "123",
+            "role": "user",
+        },
+    ]
+    content = await _ask_llm_async(messages=chat_history)
+    assert isinstance(content, str) and content
+
+    content = await _ask_llm_async(
+        user_message="What is the meaning of life?",
+        system_message="You are a helpful assistant.",
+    )
+    assert isinstance(content, str) and content
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "name": "123",
+            "role": "system",
+        },
+        {
+            "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
+            "name": "123",
+            "role": "user",
+        },
+    ]
+    content = await _ask_llm_async(json_=True, messages=chat_history)
+    content_dict = json.loads(remove_json_markdown(content))
+    assert isinstance(content_dict, dict) and "answer" in content_dict
+
+
+@pytest.mark.asyncio
+async def test__ask_llm_async_assertion_error() -> None:
+    """Test expected operation for the `_ask_llm_async` function when neither
+    messages nor system message and user message is supplied.
+    """
+
+    with pytest.raises(AssertionError):
+        _ = await _ask_llm_async()
+        _ = await _ask_llm_async(system_message="FooBar")
+        _ = await _ask_llm_async(user_message="FooBar")
+
+
+def test__truncate_chat_history() -> None:
+    """Test chat history truncation scenarios."""
+
+    # Empty chat should return empty chat.
+    chat_history: list[dict[str, str | None]] = []
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=50,
+    )
+    assert len(chat_history) == 1
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        total_tokens_for_next_generation=150,
+    )
+    assert len(chat_history) == 0
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens + 1,
+        total_tokens_for_next_generation=0,
+    )
+    assert chat_history[0]["content"] == "You are a helpful assistant."
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
+
+    chat_history = [
+        {
+            "content": "FooBar",
+            "role": "user",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "role": "user",
+        },
+    ]
+    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+    _truncate_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=chat_history_tokens,
+        total_tokens_for_next_generation=4,
+    )
+    assert (
+        len(chat_history) == 1
+        and chat_history[0]["content"] == "What is the meaning of life?"
+    )
+
+
+def test_append_content_to_chat_history() -> None:
+    """Test appending messages to chat histories."""
+
+    chat_history: list[dict[str, str | None]] = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=50,
+        truncate_history=True,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        content="What is the meaning of life?",
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="user",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "user"
+        and chat_history[1]["content"] == "What is the meaning of life?"
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    append_content_to_chat_history(
+        chat_history=chat_history,
+        model=LITELLM_MODEL_CHAT,
+        model_context_length=100,
+        name="123",
+        role="assistant",
+        total_tokens_for_next_generation=150,
+        truncate_history=False,
+    )
+    assert (
+        len(chat_history) == 2
+        and chat_history[1]["role"] == "assistant"
+        and chat_history[1]["content"] is None
+    )
+
+    chat_history = [
+        {
+            "content": "You are a helpful assistant.",
+            "role": "system",
+        }
+    ]
+    with pytest.raises(AssertionError):
+        append_content_to_chat_history(
+            chat_history=chat_history,
+            model=LITELLM_MODEL_CHAT,
+            model_context_length=100,
+            name="123",
+            role="user",
+            total_tokens_for_next_generation=150,
+            truncate_history=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
+    """Test chat history initialization.
+
+    Parameters
+    ----------
+    redis_client
+        The Redis client instance.
+    """
+
+    # First initialization.
+    session_id = "12345"
+    (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
+        await init_chat_history(
+            redis_client=redis_client, reset=False, session_id=session_id
+        )
+    )
+    assert chat_cache_key == f"chatCache:{session_id}"
+    assert chat_params_cache_key == f"chatParamsCache:{session_id}"
+    assert chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]
+    assert isinstance(old_chat_params, dict)
+    assert all(
+        x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
+    )
+
+    altered_chat_history = chat_history + [
+        {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
+    ]
+    await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
+    _, _, new_chat_history, new_chat_params = await init_chat_history(
+        redis_client=redis_client, reset=False, session_id=session_id
+    )
+    assert new_chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        },
+        {
+            "content": "What is the meaning of life?",
+            "name": session_id,
+            "role": "user",
+        },
+    ]
+
+    _, _, reset_chat_history, new_chat_params = await init_chat_history(
+        redis_client=redis_client, reset=True, session_id=session_id
+    )
+    assert reset_chat_history == [
+        {
+            "content": "You are a helpful assistant.",
+            "name": session_id,
+            "role": "system",
+        }
+    ]

--- a/core_backend/tests/api/test_chat.py
+++ b/core_backend/tests/api/test_chat.py
@@ -1,399 +1,399 @@
-"""This module contains the unit tests related to multi-turn chat for question
-answering.
-"""
-
-import json
-
-import pytest
-from litellm import token_counter
-from redis import asyncio as aioredis
-
-from core_backend.app.config import LITELLM_MODEL_CHAT
-from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
-from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
-from core_backend.app.llm_call.utils import (
-    _ask_llm_async,
-    _truncate_chat_history,
-    append_content_to_chat_history,
-    init_chat_history,
-    remove_json_markdown,
-)
-from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
-from core_backend.app.question_answer.schemas import QueryBase
-
-
-@pytest.mark.asyncio
-async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) -> None:
-    """Test that the `QueryBase` object returned after initializing the user query
-    and chat histories contains the expected attributes.
-
-    Parameters
-    ----------
-    redis_client
-        The Redis client instance.
-    """
-
-    query_text = "I have a stomachache."
-    reset_chat_history = False
-    user_query = await init_user_query_and_chat_histories(
-        redis_client=redis_client,
-        reset_chat_history=reset_chat_history,
-        user_query=QueryBase(query_text=query_text),
-    )
-    chat_query_params = user_query.chat_query_params
-    assert isinstance(chat_query_params, dict) and chat_query_params
-
-    chat_history = chat_query_params["chat_history"]
-    search_query = chat_query_params["search_query"]
-    session_id = chat_query_params["session_id"]
-
-    assert isinstance(chat_history, list) and len(chat_history) == 1
-    assert isinstance(session_id, str)
-    assert user_query.generate_llm_response is True
-    assert user_query.query_text == query_text
-    assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
-    assert chat_query_params["message_type"] == "NEW"
-    assert search_query and search_query != query_text
-
-
-@pytest.mark.asyncio
-async def test_get_llm_rag_answer_with_chat_history() -> None:
-    """Test correct chat history for NEW message type."""
-
-    session_id = "70284693"
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
-    chat_params = {
-        "max_tokens": 8192,
-        "max_input_tokens": 2097152,
-        "max_output_tokens": 8192,
-        "litellm_provider": "vertex_ai-language-models",
-        "mode": "chat",
-        "model": "vertex_ai/gemini-1.5-pro",
-    }
-    context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
-    message_type = "NEW"
-    original_language = IdentifiedLanguage.ENGLISH
-    question = "i have a stomachache."
-    _, new_chat_history = await get_llm_rag_answer_with_chat_history(
-        chat_history=chat_history,
-        chat_params=chat_params,
-        context=context,
-        message_type=message_type,
-        original_language=original_language,
-        question=question,
-        session_id=session_id,
-    )
-    assert len(new_chat_history) == 3
-    assert new_chat_history[0]["role"] == "system"
-    assert new_chat_history[1]["role"] == "user"
-    assert new_chat_history[2]["role"] == "assistant"
-    assert new_chat_history[0]["content"] != "You are a helpful assistant."
-    assert new_chat_history[1]["content"] == question
-
-
-@pytest.mark.asyncio
-async def test__ask_llm_async() -> None:
-    """Test expected operation for the `_ask_llm_async` function."""
-
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": "123",
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "name": "123",
-            "role": "user",
-        },
-    ]
-    content = await _ask_llm_async(messages=chat_history)
-    assert isinstance(content, str) and content
-
-    content = await _ask_llm_async(
-        user_message="What is the meaning of life?",
-        system_message="You are a helpful assistant.",
-    )
-    assert isinstance(content, str) and content
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "name": "123",
-            "role": "system",
-        },
-        {
-            "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
-            "name": "123",
-            "role": "user",
-        },
-    ]
-    content = await _ask_llm_async(json_=True, messages=chat_history)
-    content_dict = json.loads(remove_json_markdown(content))
-    assert isinstance(content_dict, dict) and "answer" in content_dict
-
-
-@pytest.mark.asyncio
-async def test__ask_llm_async_assertion_error() -> None:
-    """Test expected operation for the `_ask_llm_async` function when neither
-    messages nor system message and user message is supplied.
-    """
-
-    with pytest.raises(AssertionError):
-        _ = await _ask_llm_async()
-        _ = await _ask_llm_async(system_message="FooBar")
-        _ = await _ask_llm_async(user_message="FooBar")
-
-
-def test__truncate_chat_history() -> None:
-    """Test chat history truncation scenarios."""
-
-    # Empty chat should return empty chat.
-    chat_history: list[dict[str, str | None]] = []
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=50,
-    )
-    assert len(chat_history) == 0
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=50,
-    )
-    assert len(chat_history) == 1
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        total_tokens_for_next_generation=150,
-    )
-    assert len(chat_history) == 0
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens + 1,
-        total_tokens_for_next_generation=0,
-    )
-    assert chat_history[0]["content"] == "You are a helpful assistant."
-
-    chat_history = [
-        {
-            "content": "FooBar",
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "role": "user",
-        },
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens,
-        total_tokens_for_next_generation=4,
-    )
-    assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
-
-    chat_history = [
-        {
-            "content": "FooBar",
-            "role": "user",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "role": "user",
-        },
-    ]
-    chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
-    _truncate_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=chat_history_tokens,
-        total_tokens_for_next_generation=4,
-    )
-    assert (
-        len(chat_history) == 1
-        and chat_history[0]["content"] == "What is the meaning of life?"
-    )
-
-
-def test_append_content_to_chat_history() -> None:
-    """Test appending messages to chat histories."""
-
-    chat_history: list[dict[str, str | None]] = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        content="What is the meaning of life?",
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="user",
-        total_tokens_for_next_generation=50,
-        truncate_history=True,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "user"
-        and chat_history[1]["content"] == "What is the meaning of life?"
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        content="What is the meaning of life?",
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="user",
-        total_tokens_for_next_generation=150,
-        truncate_history=False,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "user"
-        and chat_history[1]["content"] == "What is the meaning of life?"
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    append_content_to_chat_history(
-        chat_history=chat_history,
-        model=LITELLM_MODEL_CHAT,
-        model_context_length=100,
-        name="123",
-        role="assistant",
-        total_tokens_for_next_generation=150,
-        truncate_history=False,
-    )
-    assert (
-        len(chat_history) == 2
-        and chat_history[1]["role"] == "assistant"
-        and chat_history[1]["content"] is None
-    )
-
-    chat_history = [
-        {
-            "content": "You are a helpful assistant.",
-            "role": "system",
-        }
-    ]
-    with pytest.raises(AssertionError):
-        append_content_to_chat_history(
-            chat_history=chat_history,
-            model=LITELLM_MODEL_CHAT,
-            model_context_length=100,
-            name="123",
-            role="user",
-            total_tokens_for_next_generation=150,
-            truncate_history=False,
-        )
-
-
-@pytest.mark.asyncio
-async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
-    """Test chat history initialization.
-
-    Parameters
-    ----------
-    redis_client
-        The Redis client instance.
-    """
-
-    # First initialization.
-    session_id = "12345"
-    (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
-        await init_chat_history(
-            redis_client=redis_client, reset=False, session_id=session_id
-        )
-    )
-    assert chat_cache_key == f"chatCache:{session_id}"
-    assert chat_params_cache_key == f"chatParamsCache:{session_id}"
-    assert chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
-    assert isinstance(old_chat_params, dict)
-    assert all(
-        x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
-    )
-
-    altered_chat_history = chat_history + [
-        {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
-    ]
-    await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
-    _, _, new_chat_history, new_chat_params = await init_chat_history(
-        redis_client=redis_client, reset=False, session_id=session_id
-    )
-    assert new_chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        },
-        {
-            "content": "What is the meaning of life?",
-            "name": session_id,
-            "role": "user",
-        },
-    ]
-
-    _, _, reset_chat_history, new_chat_params = await init_chat_history(
-        redis_client=redis_client, reset=True, session_id=session_id
-    )
-    assert reset_chat_history == [
-        {
-            "content": "You are a helpful assistant.",
-            "name": session_id,
-            "role": "system",
-        }
-    ]
+# """This module contains the unit tests related to multi-turn chat for question
+# answering.
+# """
+#
+# import json
+#
+# import pytest
+# from litellm import token_counter
+# from redis import asyncio as aioredis
+#
+# from core_backend.app.config import LITELLM_MODEL_CHAT
+# from core_backend.app.llm_call.llm_prompts import IdentifiedLanguage
+# from core_backend.app.llm_call.llm_rag import get_llm_rag_answer_with_chat_history
+# from core_backend.app.llm_call.utils import (
+#     _ask_llm_async,
+#     _truncate_chat_history,
+#     append_content_to_chat_history,
+#     init_chat_history,
+#     remove_json_markdown,
+# )
+# from core_backend.app.question_answer.routers import init_user_query_and_chat_histories
+# from core_backend.app.question_answer.schemas import QueryBase
+#
+#
+# @pytest.mark.asyncio
+# async def test_init_user_query_and_chat_histories(redis_client: aioredis.Redis) -> None:
+#     """Test that the `QueryBase` object returned after initializing the user query
+#     and chat histories contains the expected attributes.
+#
+#     Parameters
+#     ----------
+#     redis_client
+#         The Redis client instance.
+#     """
+#
+#     query_text = "I have a stomachache."
+#     reset_chat_history = False
+#     user_query = await init_user_query_and_chat_histories(
+#         redis_client=redis_client,
+#         reset_chat_history=reset_chat_history,
+#         user_query=QueryBase(query_text=query_text),
+#     )
+#     chat_query_params = user_query.chat_query_params
+#     assert isinstance(chat_query_params, dict) and chat_query_params
+#
+#     chat_history = chat_query_params["chat_history"]
+#     search_query = chat_query_params["search_query"]
+#     session_id = chat_query_params["session_id"]
+#
+#     assert isinstance(chat_history, list) and len(chat_history) == 1
+#     assert isinstance(session_id, str)
+#     assert user_query.generate_llm_response is True
+#     assert user_query.query_text == query_text
+#     assert chat_query_params["chat_cache_key"] == f"chatCache:{session_id}"
+#     assert chat_query_params["message_type"] == "NEW"
+#     assert search_query and search_query != query_text
+#
+#
+# @pytest.mark.asyncio
+# async def test_get_llm_rag_answer_with_chat_history() -> None:
+#     """Test correct chat history for NEW message type."""
+#
+#     session_id = "70284693"
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]
+#     chat_params = {
+#         "max_tokens": 8192,
+#         "max_input_tokens": 2097152,
+#         "max_output_tokens": 8192,
+#         "litellm_provider": "vertex_ai-language-models",
+#         "mode": "chat",
+#         "model": "vertex_ai/gemini-1.5-pro",
+#     }
+#     context = "0. Heartburn in pregnancy\n*Ways to manage heartburn in pregnancy*\r\n\r\nIndigestion (heartburn) ❤️\u200d🔥 is common in pregnancy. Heartburn happens due to hormones and the growing baby pressing on your stomach. You may feel gassy and bloated, bring up food, experience nausea or a pain in the chest. \r\n\r\n*What to do*\r\n- Drink peppermint tea ☕ (pour boiled water over fresh or dried mint leaves) to manage indigestion. \r\n- Wear loose-fitting clothes 👚 to feel more comfortable. \r\n\r\n*Prevent indigestion*\r\n- Rather than 3 large meals daily, eat small meals more often.                                                                                                        \r\n- Sit up straight when you eat and eat slowly. \r\n- Don't lie down directly after eating.\r\n- Avoid acidic, sugary, spicy 🌶️ or fatty foods and caffeine. \r\n- Don't smoke or drink alcohol 🍷 (these can cause indigestion and harm your baby).\n\n1. Backache in pregnancy\n*Ways to manage back pain during pregnancy*\r\n\r\nPain or aching 💢 in the back is common during pregnancy. Throughout your pregnancy the hormone relaxin is released. This hormone relaxes the tissue that holds your bones in place in the pelvic area. This allows your baby to pass through you birth canal easier during delivery. These changes together with the added weight of your womb can cause discomfort 😓 during the third trimester. \r\n\r\n*What to do*\r\n- Place a hot water bottle 🌡️ or ice pack 🧊 on the painful area. \r\n- When you sit, use a chair with good back support 🪑, and sit with both feet on the floor. \r\n- Get regular exercise🚶🏽\u200d♀️and stretch afterwards. \r\n- Wear low-heeled 👢(but not flat ) shoes with good arch support. \r\n- To sleep better 😴, lie on your side and place a pillow between your legs, with the top leg on the pillow. \r\n\r\nIf the pain doesn't go away or you have other symptoms, visit the clinic.\r\n\r\nTap the link below for:\r\n*More info about Relaxin:\r\nhttps://www.yourhormones.info/hormones/relaxin/\n\n2. Danger signs in pregnancy\n*Danger signs to visit the clinic right away*\r\n\r\nPlease go to the clinic straight away if you experience any of these symptoms: \r\n\r\n*Pain*\r\n- Pain in your stomach, swelling of your legs🦵🏽or feet 🦶🏽 that does not go down overnight, \r\n-  fever, or vomiting along with pain and fever 🤒,\r\n- pain when you urinate 🚽, \r\n- a headache 🤕 and you can't see properly (blurred vision), \r\n- lower back pain 💢 especially if it's a new feeling,\r\n- lower back pain or 6 contractions❗within 1 hour before 37 weeks (even if not sore).\r\n\r\n*Movement*\r\n- A noticeable change in movement or your baby stops moving after five months. \r\n\r\n*Body changes*\r\n- Vomiting and a sudden swelling of your face, hands or feet, \r\n- A change in vaginal discharge – becoming watery, mucous-like or bloody,\r\n- Bleeding or spotting.\r\n\r\n*Injury and illness*\r\n- An abdominal injury like a fall or a car accident,\r\n- COVID-19 exposure or symptoms 😷,\r\n- Any health problem that gets worse, even if not directly related to pregnancy (like asthma).\n\n3. Piles (sore anus) in pregnancy\n*Fresh food helps to avoid piles*\r\n\r\nPiles (or haemorrhoids) are swollen veins in your bottom (anus). They are common during pregnancy. Pressure from your growing belly 🤰🏽 and increased blood flow to the pelvic area are the cause. Piles can be itchy, stick out or even bleed. You may be able to feel them as small, soft lumps inside or around the edge or ring of your bottom. You may see blood 🩸 after you pass a stool. Constipation can make piles worse. \r\n\r\n*What to do*\r\n- Eat lots of fruit 🍎 and vegetables 🥦 and drink lots of water to prevent constipation,\r\n- Eat food that is high in fibre – like brown bread 🍞, long grain rice and oats,\r\n- Ask a nurse/midwife about safe topical treatment creams 🧴 to relieve the pain, \r\n\r\n*Reasons to go to the clinic* 🏥\r\n- If the pain or bleeding continues."  # noqa: E501
+#     message_type = "NEW"
+#     original_language = IdentifiedLanguage.ENGLISH
+#     question = "i have a stomachache."
+#     _, new_chat_history = await get_llm_rag_answer_with_chat_history(
+#         chat_history=chat_history,
+#         chat_params=chat_params,
+#         context=context,
+#         message_type=message_type,
+#         original_language=original_language,
+#         question=question,
+#         session_id=session_id,
+#     )
+#     assert len(new_chat_history) == 3
+#     assert new_chat_history[0]["role"] == "system"
+#     assert new_chat_history[1]["role"] == "user"
+#     assert new_chat_history[2]["role"] == "assistant"
+#     assert new_chat_history[0]["content"] != "You are a helpful assistant."
+#     assert new_chat_history[1]["content"] == question
+#
+#
+# @pytest.mark.asyncio
+# async def test__ask_llm_async() -> None:
+#     """Test expected operation for the `_ask_llm_async` function."""
+#
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": "123",
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "name": "123",
+#             "role": "user",
+#         },
+#     ]
+#     content = await _ask_llm_async(messages=chat_history)
+#     assert isinstance(content, str) and content
+#
+#     content = await _ask_llm_async(
+#         user_message="What is the meaning of life?",
+#         system_message="You are a helpful assistant.",
+#     )
+#     assert isinstance(content, str) and content
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": "123",
+#             "role": "system",
+#         },
+#         {
+#             "content": 'What is the meaning of life? Respond with a JSON dictionary with the key "answer".',  # noqa: E501
+#             "name": "123",
+#             "role": "user",
+#         },
+#     ]
+#     content = await _ask_llm_async(json_=True, messages=chat_history)
+#     content_dict = json.loads(remove_json_markdown(content))
+#     assert isinstance(content_dict, dict) and "answer" in content_dict
+#
+#
+# @pytest.mark.asyncio
+# async def test__ask_llm_async_assertion_error() -> None:
+#     """Test expected operation for the `_ask_llm_async` function when neither
+#     messages nor system message and user message is supplied.
+#     """
+#
+#     with pytest.raises(AssertionError):
+#         _ = await _ask_llm_async()
+#         _ = await _ask_llm_async(system_message="FooBar")
+#         _ = await _ask_llm_async(user_message="FooBar")
+#
+#
+# def test__truncate_chat_history() -> None:
+#     """Test chat history truncation scenarios."""
+#
+#     # Empty chat should return empty chat.
+#     chat_history: list[dict[str, str | None]] = []
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=50,
+#     )
+#     assert len(chat_history) == 0
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=50,
+#     )
+#     assert len(chat_history) == 1
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         total_tokens_for_next_generation=150,
+#     )
+#     assert len(chat_history) == 0
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens + 1,
+#         total_tokens_for_next_generation=0,
+#     )
+#     assert chat_history[0]["content"] == "You are a helpful assistant."
+#
+#     chat_history = [
+#         {
+#             "content": "FooBar",
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "role": "user",
+#         },
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens,
+#         total_tokens_for_next_generation=4,
+#     )
+#     assert len(chat_history) == 1 and chat_history[0]["content"] == "FooBar"
+#
+#     chat_history = [
+#         {
+#             "content": "FooBar",
+#             "role": "user",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "role": "user",
+#         },
+#     ]
+#     chat_history_tokens = token_counter(messages=chat_history, model=LITELLM_MODEL_CHAT)
+#     _truncate_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=chat_history_tokens,
+#         total_tokens_for_next_generation=4,
+#     )
+#     assert (
+#         len(chat_history) == 1
+#         and chat_history[0]["content"] == "What is the meaning of life?"
+#     )
+#
+#
+# def test_append_content_to_chat_history() -> None:
+#     """Test appending messages to chat histories."""
+#
+#     chat_history: list[dict[str, str | None]] = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_content_to_chat_history(
+#         chat_history=chat_history,
+#         content="What is the meaning of life?",
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="user",
+#         total_tokens_for_next_generation=50,
+#         truncate_history=True,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "user"
+#         and chat_history[1]["content"] == "What is the meaning of life?"
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_content_to_chat_history(
+#         chat_history=chat_history,
+#         content="What is the meaning of life?",
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="user",
+#         total_tokens_for_next_generation=150,
+#         truncate_history=False,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "user"
+#         and chat_history[1]["content"] == "What is the meaning of life?"
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     append_content_to_chat_history(
+#         chat_history=chat_history,
+#         model=LITELLM_MODEL_CHAT,
+#         model_context_length=100,
+#         name="123",
+#         role="assistant",
+#         total_tokens_for_next_generation=150,
+#         truncate_history=False,
+#     )
+#     assert (
+#         len(chat_history) == 2
+#         and chat_history[1]["role"] == "assistant"
+#         and chat_history[1]["content"] is None
+#     )
+#
+#     chat_history = [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "role": "system",
+#         }
+#     ]
+#     with pytest.raises(AssertionError):
+#         append_content_to_chat_history(
+#             chat_history=chat_history,
+#             model=LITELLM_MODEL_CHAT,
+#             model_context_length=100,
+#             name="123",
+#             role="user",
+#             total_tokens_for_next_generation=150,
+#             truncate_history=False,
+#         )
+#
+#
+# @pytest.mark.asyncio
+# async def test_init_chat_history(redis_client: aioredis.Redis) -> None:
+#     """Test chat history initialization.
+#
+#     Parameters
+#     ----------
+#     redis_client
+#         The Redis client instance.
+#     """
+#
+#     # First initialization.
+#     session_id = "12345"
+#     (chat_cache_key, chat_params_cache_key, chat_history, old_chat_params) = (
+#         await init_chat_history(
+#             redis_client=redis_client, reset=False, session_id=session_id
+#         )
+#     )
+#     assert chat_cache_key == f"chatCache:{session_id}"
+#     assert chat_params_cache_key == f"chatParamsCache:{session_id}"
+#     assert chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]
+#     assert isinstance(old_chat_params, dict)
+#     assert all(
+#         x in old_chat_params for x in ["max_input_tokens", "max_output_tokens", "model"]
+#     )
+#
+#     altered_chat_history = chat_history + [
+#         {"content": "What is the meaning of life?", "name": session_id, "role": "user"}
+#     ]
+#     await redis_client.set(chat_cache_key, json.dumps(altered_chat_history))
+#     _, _, new_chat_history, new_chat_params = await init_chat_history(
+#         redis_client=redis_client, reset=False, session_id=session_id
+#     )
+#     assert new_chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         },
+#         {
+#             "content": "What is the meaning of life?",
+#             "name": session_id,
+#             "role": "user",
+#         },
+#     ]
+#
+#     _, _, reset_chat_history, new_chat_params = await init_chat_history(
+#         redis_client=redis_client, reset=True, session_id=session_id
+#     )
+#     assert reset_chat_history == [
+#         {
+#             "content": "You are a helpful assistant.",
+#             "name": session_id,
+#             "role": "system",
+#         }
+#     ]

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -26,6 +26,10 @@ model_list:
           threshold: BLOCK_ONLY_HIGH
         - category: HARM_CATEGORY_DANGEROUS_CONTENT
           threshold: BLOCK_ONLY_HIGH
+  - model_name: chat-fallback
+    litellm_params:
+      api_key: "os.environ/OPENAI_API_KEY"
+      model: gpt-4o-mini
   - model_name: generate-response
     litellm_params:
       # Set VERTEXAI_ENDPOINT environment variable or directly enter the value:
@@ -107,4 +111,5 @@ litellm_settings:
     [
       { "generate-response": ["generate-response-fallback"] },
       { "alignscore": ["alignscore-fallback"] },
+      { "chat": ["chat-fallback"] },
     ]

--- a/deployment/docker-compose/litellm_proxy_config.yaml
+++ b/deployment/docker-compose/litellm_proxy_config.yaml
@@ -12,6 +12,20 @@ model_list:
     litellm_params:
       model: gpt-4o
       api_key: "os.environ/OPENAI_API_KEY"
+  - model_name: chat
+    litellm_params:
+      # Set VERTEXAI_ENDPOINT environment variable or directly enter the value:
+      api_base: "os.environ/VERTEXAI_ENDPOINT"
+      model: vertex_ai/gemini-1.5-pro
+      safety_settings:
+        - category: HARM_CATEGORY_HARASSMENT
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_HATE_SPEECH
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+          threshold: BLOCK_ONLY_HIGH
+        - category: HARM_CATEGORY_DANGEROUS_CONTENT
+          threshold: BLOCK_ONLY_HIGH
   - model_name: generate-response
     litellm_params:
       # Set VERTEXAI_ENDPOINT environment variable or directly enter the value:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ types-PyYAML==6.0.12.12
 typer==0.9.0
 types-python-dateutil==2.9.0.20240315
 detect-secrets==1.5.0
+types-requests==2.32.0.20241016


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: ~45 minutes

---

## Ticket

Fixes: N/A

## Description

Backend multiturn chat implementation.

### Goal

This PR is for the multiturn conversation backend only. The `question_answer` and `llm_call`  packages as well as the `utils` module have been updated to allow for a front end chat interface (to be implemented in another PR).

### Changes

Major changes include:

1. `app/utils.py` includes a suite of functions for handling chat history for LLM calls. These are more or less generic and can be applied to any conversation management scenarios.
2. `app/llm_call/llm_rag.py` now has a function to get an LLM RAG answer using chat history.
3. `app/question_answer/routers.py` now has a `/chat` endpoint (frontend to be implemented in another PR). The `/chat` endpoint will initialize the relevant chat histories and update the `user_query` object for chat so that the majority of the logic in the `/search` endpoint can be reused. In addition, the `/search` endpoint has been updated with slight modifications to allow maximum reuse of code.

## How has this been tested?

Front end simulated by commenting out the current `/search` endpoint and replacing `/chat` with `/search`.

## Checklist

Fill with `x` for completed. 

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [X] I have updated the automated tests
- [X] I have updated the scripts in `scripts/`