### PR TITLE
Hot reloadable dev setup through make rundev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,3 +139,13 @@ setup-embeddings: guard-HUGGINGFACE_MODEL guard-HUGGINGFACE_EMBEDDINGS_API_KEY
 teardown-embeddings:
 	@docker stop huggingface-embeddings
 	@docker rm  huggingface-embeddings
+
+rundev:
+	$(CONDA_ACTIVATE) $(PROJECT_NAME)
+	@docker compose -f deployment/docker-compose/docker-compose-dev.yml -p aaq-dev up --build -d --remove-orphans
+	@docker system prune -f
+
+stopdev:
+	@docker compose -f deployment/docker-compose/docker-compose-dev.yml -p aaq-dev down
+
+restartdev: stopdev rundev

--- a/admin_app/Dockerfile.dev
+++ b/admin_app/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:19-alpine
+
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=development
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+CMD ["npm", "run", "dev"]

--- a/core_backend/Dockerfile.dev
+++ b/core_backend/Dockerfile.dev
@@ -1,0 +1,44 @@
+FROM python:3.10-slim-buster
+
+LABEL maintainer="IDinsight"
+
+# Define arguments
+ARG NAME=aaq_backend
+ARG PORT=8000
+ARG HOME_DIR=/usr/src/${NAME}
+ARG WHISPER_MODEL_DIR=/whisper_models
+
+# Install packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libpq-dev python3-dev ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up directories
+RUN mkdir -p ${HOME_DIR} ${WHISPER_MODEL_DIR} /tmp/prometheus
+
+# Set environment variables
+ENV PYTHONPATH="${PYTHONPATH}:${HOME_DIR}"
+ENV PORT=${PORT}
+ENV WHISPER_MODEL_DIR=${WHISPER_MODEL_DIR}
+
+# Set working directory
+WORKDIR ${HOME_DIR}
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Copy application code
+COPY . .
+
+# Make startup script executable
+RUN chmod +x startup.sh
+
+# Download required models
+RUN python -c "from transformers import AutoModel; AutoModel.from_pretrained('cross-encoder/ms-marco-MiniLM-L-6-v2')" && \
+    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" && \
+    python -c "from faster_whisper import WhisperModel; model = WhisperModel('tiny', download_root='${WHISPER_MODEL_DIR}')"
+
+EXPOSE ${PORT}
+
+CMD ["python", "main.py"]

--- a/core_backend/app/__init__.py
+++ b/core_backend/app/__init__.py
@@ -4,8 +4,6 @@ from contextlib import asynccontextmanager
 from typing import AsyncIterator, Callable
 
 import sentry_sdk
-import sklearn  # noqa
-import torch  # noqa
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess

--- a/core_backend/main.py
+++ b/core_backend/main.py
@@ -20,4 +20,11 @@ class Worker(UvicornWorker):
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     logger.setLevel(logging.DEBUG)
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True, log_level="debug")
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level="debug",
+        root_path=BACKEND_ROOT_PATH,
+    )

--- a/deployment/docker-compose/docker-compose-dev.yml
+++ b/deployment/docker-compose/docker-compose-dev.yml
@@ -1,0 +1,106 @@
+services:
+  core_backend:
+    image: idinsight/aaq-backend:latest
+    build:
+      context: ../../core_backend
+      dockerfile: Dockerfile.dev
+    command: >
+      /bin/sh -c "
+      python -m alembic upgrade head &&
+      python main.py"
+    restart: always
+    volumes:
+      - ../../core_backend:/usr/src/aaq_backend
+      - temp:/usr/src/aaq_backend/temp
+      - ./.gcp_credentials.json:/app/credentials.json
+    env_file:
+      - .base.env
+      - .core_backend.env
+      - .litellm_proxy.env
+    environment:
+      - REDIS_HOST=redis://redis:6379
+      - LITELLM_ENDPOINT=http://litellm_proxy:4000
+      - POSTGRES_HOST=relational_db
+    depends_on:
+      - redis
+      - relational_db
+
+  admin_app:
+    image: idinsight/aaq-admin-app:latest
+    build:
+      context: ../../admin_app
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ../../admin_app:/app
+    depends_on:
+      - core_backend
+    restart: always
+    env_file:
+      - .base.env
+
+  caddy:
+    image: caddy:2.7.6
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    env_file:
+      - .base.env
+
+  litellm_proxy:
+    image: ghcr.io/berriai/litellm:main-v1.40.10
+    restart: always
+    env_file:
+      - .litellm_proxy.env
+    volumes:
+      - ./litellm_proxy_config.yaml:/app/config.yaml
+      - ./.gcp_credentials.json:/app/credentials.json
+    ports: # Expose the port to port 4001 for debugging purposes
+      - 4001:4000
+    command: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "4"]
+
+  huggingface-embeddings:
+    # image either refers to locally built image or defaults to the one from the registry
+    image: ${EMBEDDINGS_IMAGE_NAME:-ghcr.io/huggingface/text-embeddings-inference:cpu-1.5}
+    profiles:
+      - huggingface-embeddings
+      - optional-components
+    volumes:
+      - $PWD/data:/data
+    command:
+      [
+        "--model-id",
+        "${HUGGINGFACE_MODEL}",
+        "--api-key",
+        "${HUGGINGFACE_EMBEDDINGS_API_KEY}",
+      ]
+    restart: always
+    env_file:
+      - .litellm_proxy.env
+
+  redis:
+    image: "redis:6.0-alpine"
+    ports: # Expose the port to port 6380 on the host machine for debugging
+      - "6380:6379"
+    restart: always
+
+  relational_db:
+    image: pgvector/pgvector:pg16
+    restart: always
+    env_file:
+      - .core_backend.env
+    volumes:
+      - db_volume:/var/lib/postgresql/data
+    ports: # Expose the port to port 5434 on the host machine for debugging
+      - 5434:5432
+
+volumes:
+  caddy_data:
+  caddy_config:
+  temp:
+  db_volume:


### PR DESCRIPTION
Reviewer: @lickem22
Estimate: 10 minutes

---

## Ticket

Fixes: [JIRA_TICKET_LINK](https://idinsight.atlassian.net/browse/AAQ-902)

## Description
Added the ability to run `make rundev` which will run the back end and front-end in hot reload mode, ie, changes made to the app will be reflected instantly.

### Goal
Make dev faster and easier.

### Changes
- Added docker-compose-dev.yml (similar to .dev but did not want to delete that assuming some people prefer it)
- Added make commands - rundev, stopdev, restartdev
- Added

### Future Tasks (optional)
- Delete docker-compose.dev.yml if people don't mind
- Update the ReadMe if this is how we want to tell people to set up their dev environment

## How has this been tested?
- Ran make rundev/stopdev/restartdev
- Changed stuff in the backend and saw that it reflected instantly (5 seconds)
- Changed stuff in the front-end and saw that it got reflected instantly (1 second)

## To-do before merge (optional)
- Test yourself by running make rundev and modifying stuff and seeing it change instantly 

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates