### PR TITLE
Allow multi selection for faster bulk delete

### DIFF
--- a/admin_app/src/app/content/components/ContentCard.tsx
+++ b/admin_app/src/app/content/components/ContentCard.tsx
@@ -1,7 +1,15 @@
 import { ContentViewModal, ArchiveContentModal } from "./ContentModal";
 import { appColors, appStyles, sizes } from "@/utils";
 import { Delete, Edit } from "@mui/icons-material";
-import { Box, Button, Card, Chip, IconButton, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Chip,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
 import React from "react";
 import { Layout } from "../../../components/Layout";
@@ -22,6 +30,9 @@ const ContentCard = ({
   onFailedArchive,
   archiveContent,
   editAccess,
+  isSelectMode,
+  selectedContents,
+  setSelectedContents,
 }: {
   title: string;
   text: string;
@@ -34,14 +45,23 @@ const ContentCard = ({
   onFailedArchive: (content_id: number) => void;
   archiveContent: (content_id: number) => Promise<any>;
   editAccess: boolean;
+  isSelectMode: boolean;
+  selectedContents: number[];
+  setSelectedContents: (selectedContents: number[]) => void;
 }) => {
   const [openReadModal, setOpenReadModal] = React.useState<boolean>(false);
   const [openArchiveModal, setOpenArchiveModal] = React.useState<boolean>(false);
+  const [isHovered, setIsHovered] = React.useState<boolean>(false);
+  const [checked, setChecked] = React.useState<boolean>(
+    selectedContents.includes(content_id),
+  );
 
   return (
     <>
       <Card
         onClick={() => setOpenReadModal(true)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
         sx={[
           {
             cursor: "pointer",
@@ -51,11 +71,35 @@ const ContentCard = ({
             justifyContent: "space-between",
             height: CARD_HEIGHT,
             minWidth: CARD_MIN_WIDTH,
+            position: "relative",
           },
           appStyles.hoverShadow,
           appStyles.shadow,
         ]}
       >
+        <Box
+          sx={{
+            position: "absolute",
+            top: 8,
+            left: 8,
+            opacity: isHovered || isSelectMode ? 1 : 0,
+            transition: "opacity 0.2s ease-in-out",
+            zIndex: 1,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={checked}
+            onChange={(e) => {
+              const newChecked = e.target.checked;
+              if (newChecked && !selectedContents.includes(content_id)) {
+                setSelectedContents([...selectedContents, content_id]);
+              }
+              setChecked(newChecked);
+            }}
+            size="small"
+          />
+        </Box>
         <Layout.FlexBox flexDirection="row" justifyContent="end" sx={{ width: "98%" }}>
           {tags && tags.length > 0 && (
             <Box display="flex" flexDirection="row" alignItems="center">
@@ -105,7 +149,11 @@ const ContentCard = ({
         <Layout.FlexBox
           flexDirection={"row"}
           gap={sizes.tinyGap}
-          sx={{ alignItems: "center" }}
+          sx={{
+            alignItems: "center",
+            opacity: isHovered ? 1 : 0,
+            transition: "opacity 0.2s ease-in-out",
+          }}
         >
           <Button
             disabled={!editAccess}

--- a/admin_app/src/app/content/components/ContentCard.tsx
+++ b/admin_app/src/app/content/components/ContentCard.tsx
@@ -56,6 +56,10 @@ const ContentCard = ({
     selectedContents.includes(content_id),
   );
 
+  React.useEffect(() => {
+    setChecked(selectedContents.includes(content_id));
+  }, [selectedContents]);
+
   return (
     <>
       <Card
@@ -94,6 +98,8 @@ const ContentCard = ({
               const newChecked = e.target.checked;
               if (newChecked && !selectedContents.includes(content_id)) {
                 setSelectedContents([...selectedContents, content_id]);
+              } else if (!newChecked && selectedContents.includes(content_id)) {
+                setSelectedContents(selectedContents.filter((id) => id !== content_id));
               }
               setChecked(newChecked);
             }}

--- a/admin_app/src/app/content/components/ContentCard.tsx
+++ b/admin_app/src/app/content/components/ContentCard.tsx
@@ -178,6 +178,7 @@ const ContentCard = ({
             size="medium"
             onClick={(event) => {
               event.stopPropagation();
+              setSelectedContents(selectedContents.filter((id) => id !== content_id));
               setOpenArchiveModal(true);
             }}
           >

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -9,7 +9,9 @@ import {
   Button,
   ButtonGroup,
   CircularProgress,
+  Divider,
   Fab,
+  Fade,
   Grid,
   Menu,
   MenuItem,
@@ -23,7 +25,14 @@ import {
   Typography,
 } from "@mui/material";
 
-import { ChevronLeft, ChevronRight, Delete } from "@mui/icons-material";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Delete,
+  Delete as DeleteIcon,
+  WarningAmber as WarningIcon,
+  Close as CloseIcon,
+} from "@mui/icons-material";
 import AddIcon from "@mui/icons-material/Add";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import DownloadIcon from "@mui/icons-material/Download";
@@ -884,8 +893,6 @@ const CardsGrid = ({
   );
 };
 
-export default CardsPage;
-
 const ConfirmDeleteModal: React.FC<{
   open: boolean;
   onClose: () => void;
@@ -901,72 +908,135 @@ const ConfirmDeleteModal: React.FC<{
     }
   };
 
+  // Handle enter key press
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && confirmationText.toLowerCase() === "delete") {
+      handleConfirm();
+    }
+  };
+
   return (
     <Modal
       open={open}
       onClose={onClose}
+      closeAfterTransition
       aria-labelledby="confirm-delete-modal-title"
       aria-describedby="confirm-delete-modal-description"
     >
-      <Box
-        sx={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          width: 400,
-          bgcolor: "background.paper",
-          border: "2px solid #000",
-          boxShadow: 24,
-          p: 4,
-          borderRadius: 2,
-        }}
-      >
-        <Typography
-          id="confirm-delete-modal-title"
-          variant="h6"
-          component="h2"
-          gutterBottom
-        >
-          Confirm Deletion
-        </Typography>
-        <Typography id="confirm-delete-modal-description" variant="body1" gutterBottom>
-          Are you sure you want to delete {selectedContentsCount} content
-          {selectedContentsCount > 1 ? "s" : ""}? This action cannot be undone.
-        </Typography>
-        <Typography variant="body2" color="textSecondary" gutterBottom>
-          Type <strong>delete</strong> in the field below to confirm.
-        </Typography>
-        <TextField
-          fullWidth
-          variant="outlined"
-          size="small"
-          value={confirmationText}
-          onChange={(e) => setConfirmationText(e.target.value)}
-          placeholder="Type 'delete' to confirm"
-          sx={{ mt: 2 }}
-        />
-        <Box
+      <Fade in={open}>
+        <Paper
+          elevation={6}
           sx={{
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 2,
-            mt: 3,
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: 450,
+            maxWidth: "90vw",
+            bgcolor: "background.paper",
+            borderRadius: 3,
+            overflow: "hidden",
           }}
         >
-          <Button variant="outlined" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={handleConfirm}
-            disabled={confirmationText.toLowerCase() !== "delete"}
+          {/* Header */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              bgcolor: "error.light",
+              py: 2,
+              px: 3,
+              color: "white",
+            }}
           >
-            Delete
-          </Button>
-        </Box>
-      </Box>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <DeleteIcon />
+              <Typography id="confirm-delete-modal-title" variant="h6" component="h2">
+                Confirm Deletion
+              </Typography>
+            </Box>
+            <IconButton size="small" onClick={onClose} sx={{ color: "white" }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+
+          <Divider />
+
+          {/* Content */}
+          <Box sx={{ p: 3 }}>
+            <Alert severity="warning" icon={<WarningIcon />} sx={{ mb: 2 }}>
+              This action cannot be undone
+            </Alert>
+
+            <Typography
+              id="confirm-delete-modal-description"
+              variant="body1"
+              sx={{ mb: 3 }}
+            >
+              You are about to permanently delete{" "}
+              <strong>{selectedContentsCount}</strong> content
+              {selectedContentsCount > 1 ? "s" : ""}.
+            </Typography>
+
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Type <strong>delete</strong> to confirm:
+            </Typography>
+
+            <TextField
+              fullWidth
+              variant="outlined"
+              size="small"
+              value={confirmationText}
+              onChange={(e) => setConfirmationText(e.target.value)}
+              placeholder="Type 'delete' to confirm"
+              onKeyDown={handleKeyDown}
+              autoFocus
+              InputProps={{
+                sx: { borderRadius: 1.5 },
+              }}
+            />
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 2,
+              p: 3,
+              pt: 1,
+            }}
+          >
+            <Button
+              variant="outlined"
+              onClick={onClose}
+              sx={{
+                borderRadius: 1.5,
+                textTransform: "none",
+                fontWeight: 500,
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={handleConfirm}
+              disabled={confirmationText.toLowerCase() !== "delete"}
+              startIcon={<DeleteIcon />}
+              sx={{
+                borderRadius: 1.5,
+                textTransform: "none",
+                fontWeight: 500,
+                boxShadow: 2,
+              }}
+            >
+              Delete Items
+            </Button>
+          </Box>
+        </Paper>
+      </Fade>
     </Modal>
   );
 };
+
+export default CardsPage;

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -22,7 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import { ChevronLeft, ChevronRight } from "@mui/icons-material";
+import { ChevronLeft, ChevronRight, Delete } from "@mui/icons-material";
 import AddIcon from "@mui/icons-material/Add";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import DownloadIcon from "@mui/icons-material/Download";
@@ -55,6 +55,8 @@ interface TagsFilterProps {
 
 interface CardsUtilityStripProps extends TagsFilterProps, SearchBarProps {
   editAccess: boolean;
+  selectedContents: number[];
+  setSelectedContents: React.Dispatch<React.SetStateAction<number[]>>;
   setSnackMessage: React.Dispatch<{
     message: string | null;
     color: "success" | "info" | "warning" | "error" | undefined;
@@ -77,6 +79,8 @@ interface CardsGridProps {
   handleSidebarToggle: () => void;
   openChatSidebar: boolean;
   handleChatSidebarToggle: () => void;
+  selectedContents: number[];
+  setSelectedContents: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 const CardsPage = () => {
@@ -96,6 +100,7 @@ const CardsPage = () => {
 
   const [openSearchSidebar, setOpenSideBar] = useState(false);
   const [openChatSidebar, setOpenChatSideBar] = useState(false);
+  const [selectedContents, setSelectedContents] = React.useState<number[]>([]);
   const handleSidebarToggle = () => {
     setOpenChatSideBar(false);
     setOpenSideBar(!openSearchSidebar);
@@ -205,6 +210,8 @@ const CardsPage = () => {
                 searchTerm={searchTerm}
                 setSearchTerm={setSearchTerm}
                 tags={tags}
+                selectedContents={selectedContents}
+                setSelectedContents={setSelectedContents}
                 filterTags={filterTags}
                 setFilterTags={setFilterTags}
                 setSnackMessage={setSnackMessage}
@@ -222,6 +229,8 @@ const CardsPage = () => {
                 handleSidebarToggle={handleSidebarToggle}
                 openChatSidebar={openChatSidebar}
                 handleChatSidebarToggle={handleChatSidebarToggle}
+                selectedContents={selectedContents}
+                setSelectedContents={setSelectedContents}
               />
             </Box>
           </Box>
@@ -292,6 +301,8 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
   searchTerm,
   setSearchTerm,
   tags,
+  selectedContents,
+  setSelectedContents,
   filterTags,
   setFilterTags,
   setSnackMessage,
@@ -303,7 +314,7 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
       sx={{
         display: "flex",
         flexDirection: "row",
-        justifyContent: "flex-end",
+        justifyContent: "space-between",
         alignContent: "flex-end",
         width: "100%",
         paddingBottom: 2,
@@ -311,6 +322,7 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
         gap: sizes.baseGap,
       }}
     >
+      {/* Left section - Search and Filters */}
       <Box
         sx={{
           display: "flex",
@@ -332,7 +344,49 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
           />
         </Box>
       </Box>
-      <Box sx={{ flexGrow: 1 }} />
+
+      {/* Middle section - Selection Control Buttons */}
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: sizes.smallGap,
+        }}
+      >
+        <Button
+          variant="outlined"
+          size="small"
+          //onClick={handleSelectAll}
+          disabled={!editAccess}
+        >
+          Select All
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={() => {
+            setSelectedContents([]);
+          }}
+          disabled={!editAccess || selectedContents.length === 0}
+        >
+          Deselect All
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          size="small"
+          //onClick={}
+          disabled={!editAccess || selectedContents.length === 0}
+
+          // startIcon={<Delete />}
+        >
+          Delete
+        </Button>
+      </Box>
+
+      {/* Right section - Download and Add buttons */}
       <Box
         sx={{
           display: "flex",
@@ -458,6 +512,8 @@ const CardsGrid = ({
   handleSidebarToggle,
   openChatSidebar,
   handleChatSidebarToggle,
+  selectedContents,
+  setSelectedContents,
 }: CardsGridProps) => {
   const [page, setPage] = React.useState<number>(1);
   const [maxCardsPerPage, setMaxCardsPerPage] = useState(1);
@@ -465,7 +521,6 @@ const CardsGrid = ({
   const [columns, setColumns] = React.useState<number>(1);
   const [cards, setCards] = React.useState<Content[]>([]);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
-  const [selectedContents, setSelectedContents] = React.useState<number[]>([]);
   const gridRef = React.useRef<HTMLDivElement>(null);
 
   // Callback ref to handle when the grid element mounts
@@ -673,6 +728,7 @@ const CardsGrid = ({
                           return archiveContent(content_id, token!);
                         }}
                         editAccess={editAccess}
+                        isSelectMode={selectedContents.length > 0}
                         selectedContents={selectedContents}
                         setSelectedContents={setSelectedContents}
                       />

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -13,6 +13,7 @@ import {
   Grid,
   Menu,
   MenuItem,
+  Modal,
   Paper,
   Slide,
   SlideProps,
@@ -41,6 +42,7 @@ import { DownloadModal } from "./components/DownloadModal";
 import { ImportModal } from "./components/ImportModal";
 import { SearchBar, SearchBarProps } from "./components/SearchBar";
 import { SearchSidebar } from "./components/SearchSidebar";
+import { set } from "date-fns";
 
 export interface Tag {
   tag_id: number;
@@ -55,19 +57,20 @@ interface TagsFilterProps {
 
 interface CardsUtilityStripProps extends TagsFilterProps, SearchBarProps {
   editAccess: boolean;
+  cards: Content[];
   selectedContents: number[];
   setSelectedContents: React.Dispatch<React.SetStateAction<number[]>>;
   setSnackMessage: React.Dispatch<{
     message: string | null;
     color: "success" | "info" | "warning" | "error" | undefined;
   }>;
+  handleDelete: () => void;
 }
 
 interface CardsGridProps {
   displayLanguage: string;
-  searchTerm: string;
   tags: Tag[];
-  filterTags: Tag[];
+  cards: Content[];
   openSidebar: boolean;
   token: string | null;
   editAccess: boolean;
@@ -81,6 +84,8 @@ interface CardsGridProps {
   handleChatSidebarToggle: () => void;
   selectedContents: number[];
   setSelectedContents: React.Dispatch<React.SetStateAction<number[]>>;
+  isLoading: boolean;
+  setRefreshKey: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const CardsPage = () => {
@@ -100,7 +105,11 @@ const CardsPage = () => {
 
   const [openSearchSidebar, setOpenSideBar] = useState(false);
   const [openChatSidebar, setOpenChatSideBar] = useState(false);
+  const [cards, setCards] = React.useState<Content[]>([]);
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [refreshKey, setRefreshKey] = React.useState(0);
   const [selectedContents, setSelectedContents] = React.useState<number[]>([]);
+  const [openBulkDeleteModal, setOpenBulkDeleteModal] = React.useState<boolean>(false);
   const handleSidebarToggle = () => {
     setOpenChatSideBar(false);
     setOpenSideBar(!openSearchSidebar);
@@ -138,7 +147,76 @@ const CardsPage = () => {
   const SnackbarSlideTransition = (props: SlideProps) => {
     return <Slide {...props} direction="up" />;
   };
+  const handleBulkDeleteModalClose = () => {
+    setOpenBulkDeleteModal(false);
+    setSelectedContents([]);
+  };
 
+  const handleDelete = async (selectedContents: number[]) => {
+    const promises = selectedContents.map((content_id) =>
+      archiveContent(content_id, token!),
+    );
+    try {
+      await Promise.all(promises);
+      setSnackMessage({
+        message: `Deleted ${selectedContents.length} content${
+          selectedContents.length > 1 ? "s" : ""
+        }`,
+        color: "success",
+      });
+    } catch (error) {
+      console.error("Failed to delete content:", error);
+      setSnackMessage({
+        message: `Failed to delete content`,
+        color: "error",
+      });
+    } finally {
+      setSelectedContents([]);
+      setOpenBulkDeleteModal(false);
+      setRefreshKey((prevKey) => prevKey + 1);
+    }
+  };
+  React.useEffect(() => {
+    if (token) {
+      getContentList({ token: token, skip: 0 })
+        .then((data) => {
+          const filteredData = data.filter((card: Content) => {
+            const matchesSearchTerm =
+              card.content_title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+              card.content_text.toLowerCase().includes(searchTerm.toLowerCase());
+
+            const matchesAllTags = filterTags.some((fTag) =>
+              card.content_tags.includes(fTag.tag_id),
+            );
+
+            return matchesSearchTerm && (filterTags.length === 0 || matchesAllTags);
+          });
+
+          setCards(filteredData);
+          setIsLoading(false);
+
+          const message = localStorage.getItem("editPageSnackMessage");
+          if (message) {
+            setSnackMessage({
+              message: message,
+              color: "success",
+            });
+            localStorage.removeItem("editPageSnackMessage");
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to fetch content:", error);
+          setSnackMessage({
+            message: `Failed to fetch content`,
+            color: "error",
+          });
+          setIsLoading(false);
+        });
+    } else {
+      setCards([]);
+      setIsLoading(false);
+    }
+  }, [searchTerm, filterTags, token, refreshKey]);
   return (
     <>
       <Grid container sx={{ height: "100%" }}>
@@ -209,18 +287,21 @@ const CardsPage = () => {
                 editAccess={editAccess}
                 searchTerm={searchTerm}
                 setSearchTerm={setSearchTerm}
+                cards={cards}
                 tags={tags}
                 selectedContents={selectedContents}
                 setSelectedContents={setSelectedContents}
                 filterTags={filterTags}
                 setFilterTags={setFilterTags}
                 setSnackMessage={setSnackMessage}
+                handleDelete={() => {
+                  setOpenBulkDeleteModal(true);
+                }}
               />
               <CardsGrid
                 displayLanguage={displayLanguage}
-                searchTerm={searchTerm}
                 tags={tags}
-                filterTags={filterTags}
+                cards={cards}
                 openSidebar={openSearchSidebar || openChatSidebar}
                 token={token}
                 editAccess={editAccess}
@@ -231,6 +312,16 @@ const CardsPage = () => {
                 handleChatSidebarToggle={handleChatSidebarToggle}
                 selectedContents={selectedContents}
                 setSelectedContents={setSelectedContents}
+                isLoading={isLoading}
+                setRefreshKey={setRefreshKey}
+              />
+              <ConfirmDeleteModal
+                open={openBulkDeleteModal}
+                onClose={handleBulkDeleteModalClose}
+                onConfirm={() => {
+                  handleDelete(selectedContents);
+                }}
+                selectedContentsCount={selectedContents.length}
               />
             </Box>
           </Box>
@@ -300,15 +391,25 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
   editAccess,
   searchTerm,
   setSearchTerm,
+  cards,
   tags,
   selectedContents,
   setSelectedContents,
   filterTags,
   setFilterTags,
   setSnackMessage,
+  handleDelete,
 }) => {
   const [openDownloadModal, setOpenDownloadModal] = React.useState<boolean>(false);
 
+  const handleSelectAll = () => {
+    const allContentIds = cards.map((card) => card.content_id!);
+    setSelectedContents(allContentIds);
+  };
+
+  const handleDeSelectAll = () => {
+    setSelectedContents([]);
+  };
   return (
     <Box
       sx={{
@@ -346,45 +447,46 @@ const CardsUtilityStrip: React.FC<CardsUtilityStripProps> = ({
       </Box>
 
       {/* Middle section - Selection Control Buttons */}
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: sizes.smallGap,
-        }}
-      >
-        <Button
-          variant="outlined"
-          size="small"
-          //onClick={handleSelectAll}
-          disabled={!editAccess}
-        >
-          Select All
-        </Button>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => {
-            setSelectedContents([]);
+      {selectedContents.length > 0 && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: sizes.smallGap,
           }}
-          disabled={!editAccess || selectedContents.length === 0}
         >
-          Deselect All
-        </Button>
-        <Button
-          variant="contained"
-          color="error"
-          size="small"
-          //onClick={}
-          disabled={!editAccess || selectedContents.length === 0}
-
-          // startIcon={<Delete />}
-        >
-          Delete
-        </Button>
-      </Box>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleSelectAll}
+            disabled={!editAccess}
+          >
+            Select All
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleDeSelectAll}
+            disabled={!editAccess || selectedContents.length === 0}
+          >
+            Deselect All
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            onClick={() => {
+              handleDelete();
+            }}
+            disabled={!editAccess || selectedContents.length === 0}
+            startIcon={<Delete />}
+          >
+            Delete
+          </Button>
+        </Box>
+      )}
 
       {/* Right section - Download and Add buttons */}
       <Box
@@ -501,10 +603,8 @@ const AddButtonWithDropdown: React.FC<{ editAccess: boolean }> = ({ editAccess }
 };
 
 const CardsGrid = ({
-  displayLanguage,
-  searchTerm,
   tags,
-  filterTags,
+  cards,
   token,
   editAccess,
   setSnackMessage,
@@ -514,13 +614,15 @@ const CardsGrid = ({
   handleChatSidebarToggle,
   selectedContents,
   setSelectedContents,
+  isLoading,
+  setRefreshKey,
 }: CardsGridProps) => {
   const [page, setPage] = React.useState<number>(1);
   const [maxCardsPerPage, setMaxCardsPerPage] = useState(1);
-  const [maxPages, setMaxPages] = React.useState<number>(1);
+  const [maxPages, setMaxPages] = React.useState<number>(
+    Math.ceil(cards.length / maxCardsPerPage),
+  );
   const [columns, setColumns] = React.useState<number>(1);
-  const [cards, setCards] = React.useState<Content[]>([]);
-  const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const gridRef = React.useRef<HTMLDivElement>(null);
 
   // Callback ref to handle when the grid element mounts
@@ -557,59 +659,21 @@ const CardsGrid = ({
     };
   }, []);
 
-  const [refreshKey, setRefreshKey] = React.useState(0);
+  React.useEffect(() => {
+    setMaxPages(Math.ceil(cards.length / maxCardsPerPage));
+  }, [cards, maxCardsPerPage]);
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [cards]);
+
   const onSuccessfulArchive = (content_id: number) => {
-    setIsLoading(true);
     setRefreshKey((prevKey) => prevKey + 1);
     setSnackMessage({
       message: `Content removed successfully`,
       color: "success",
     });
   };
-
-  React.useEffect(() => {
-    if (token) {
-      getContentList({ token: token, skip: 0 })
-        .then((data) => {
-          const filteredData = data.filter((card: Content) => {
-            const matchesSearchTerm =
-              card.content_title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-              card.content_text.toLowerCase().includes(searchTerm.toLowerCase());
-
-            const matchesAllTags = filterTags.some((fTag) =>
-              card.content_tags.includes(fTag.tag_id),
-            );
-
-            return matchesSearchTerm && (filterTags.length === 0 || matchesAllTags);
-          });
-
-          setCards(filteredData);
-          setMaxPages(Math.ceil(filteredData.length / maxCardsPerPage));
-          setIsLoading(false);
-
-          const message = localStorage.getItem("editPageSnackMessage");
-          if (message) {
-            setSnackMessage({
-              message: message,
-              color: "success",
-            });
-            localStorage.removeItem("editPageSnackMessage");
-          }
-        })
-        .catch((error) => {
-          console.error("Failed to fetch content:", error);
-          setSnackMessage({
-            message: `Failed to fetch content`,
-            color: "error",
-          });
-          setIsLoading(false);
-        });
-    } else {
-      setCards([]);
-      setMaxPages(1);
-      setIsLoading(false);
-    }
-  }, [searchTerm, filterTags, maxCardsPerPage, token, refreshKey]);
 
   if (isLoading) {
     return (
@@ -821,3 +885,88 @@ const CardsGrid = ({
 };
 
 export default CardsPage;
+
+const ConfirmDeleteModal: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  selectedContentsCount: number;
+}> = ({ open, onClose, onConfirm, selectedContentsCount }) => {
+  const [confirmationText, setConfirmationText] = React.useState<string>("");
+
+  const handleConfirm = () => {
+    if (confirmationText.toLowerCase() === "delete") {
+      onConfirm();
+      setConfirmationText("");
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      aria-labelledby="confirm-delete-modal-title"
+      aria-describedby="confirm-delete-modal-description"
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 400,
+          bgcolor: "background.paper",
+          border: "2px solid #000",
+          boxShadow: 24,
+          p: 4,
+          borderRadius: 2,
+        }}
+      >
+        <Typography
+          id="confirm-delete-modal-title"
+          variant="h6"
+          component="h2"
+          gutterBottom
+        >
+          Confirm Deletion
+        </Typography>
+        <Typography id="confirm-delete-modal-description" variant="body1" gutterBottom>
+          Are you sure you want to delete {selectedContentsCount} content
+          {selectedContentsCount > 1 ? "s" : ""}? This action cannot be undone.
+        </Typography>
+        <Typography variant="body2" color="textSecondary" gutterBottom>
+          Type <strong>delete</strong> in the field below to confirm.
+        </Typography>
+        <TextField
+          fullWidth
+          variant="outlined"
+          size="small"
+          value={confirmationText}
+          onChange={(e) => setConfirmationText(e.target.value)}
+          placeholder="Type 'delete' to confirm"
+          sx={{ mt: 2 }}
+        />
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 2,
+            mt: 3,
+          }}
+        >
+          <Button variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleConfirm}
+            disabled={confirmationText.toLowerCase() !== "delete"}
+          >
+            Delete
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};

--- a/admin_app/src/app/content/page.tsx
+++ b/admin_app/src/app/content/page.tsx
@@ -465,7 +465,7 @@ const CardsGrid = ({
   const [columns, setColumns] = React.useState<number>(1);
   const [cards, setCards] = React.useState<Content[]>([]);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
-
+  const [selectedContents, setSelectedContents] = React.useState<number[]>([]);
   const gridRef = React.useRef<HTMLDivElement>(null);
 
   // Callback ref to handle when the grid element mounts
@@ -673,6 +673,8 @@ const CardsGrid = ({
                           return archiveContent(content_id, token!);
                         }}
                         editAccess={editAccess}
+                        selectedContents={selectedContents}
+                        setSelectedContents={setSelectedContents}
                       />
                     </Grid>
                   );


### PR DESCRIPTION
Reviewer: @poornimaramesh 
Estimate: 30mins

---

## Ticket

Fixes: [AAQ-909](https://idinsight.atlassian.net/browse/AAQ-909)

## Description

### Goal
The goal of this PR is to allow multi-selection of contents to make content deletion easier. 
### Changes
- Only display edit and delete button on hover
- Added a checkbox on top left to select contents to delete
- Added three button : `Select all`, `Deselect all` and `Delete` that only appear when at least one content is selected
- 
### Future Tasks (optional)

## How has this been tested?
By manually testing the feature making sure everything works. Added content and deleted them using the multi-selection method. 

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts


[AAQ-909]: https://idinsight.atlassian.net/browse/AAQ-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ