### PR TITLE
Better langfuse tracing

### DIFF
--- a/core_backend/app/contents/models.py
+++ b/core_backend/app/contents/models.py
@@ -138,7 +138,6 @@ async def save_content_to_db(
     """
 
     metadata = {
-        "trace_workspace_id": "workspace_id-" + str(workspace_id),
         "generation_name": "save_content_to_db",
     }
 
@@ -204,7 +203,6 @@ async def update_content_in_db(
     """
 
     metadata = {
-        "trace_workspace_id": "workspace_id-" + str(workspace_id),
         "generation_name": "update_content_in_db",
     }
 
@@ -428,9 +426,6 @@ async def get_similar_content_async(
         A dictionary of similar content items if they exist, otherwise an empty
         dictionary.
     """
-
-    metadata = metadata or {}
-    metadata["generation_name"] = "get_similar_content_async"
 
     question_embedding = await embedding(metadata=metadata, text_to_embed=question)
 

--- a/core_backend/app/contents/routers.py
+++ b/core_backend/app/contents/routers.py
@@ -6,7 +6,7 @@ import pandas as pd
 import sqlalchemy.exc
 from fastapi import APIRouter, Depends, UploadFile, status
 from fastapi.exceptions import HTTPException
-from langfuse.decorators import observe
+from langfuse.decorators import observe  # type: ignore
 from pandas.errors import EmptyDataError, ParserError
 from pydantic import BaseModel
 from sqlalchemy import select

--- a/core_backend/app/contents/routers.py
+++ b/core_backend/app/contents/routers.py
@@ -6,6 +6,7 @@ import pandas as pd
 import sqlalchemy.exc
 from fastapi import APIRouter, Depends, UploadFile, status
 from fastapi.exceptions import HTTPException
+from langfuse.decorators import observe
 from pandas.errors import EmptyDataError, ParserError
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -63,6 +64,7 @@ class ExceedsContentQuotaError(Exception):
 
 
 @router.post("/", response_model=ContentRetrieve)
+@observe()
 async def create_content(
     content: ContentCreate,
     calling_user_db: Annotated[UserDB, Depends(get_current_user)],
@@ -164,6 +166,7 @@ async def create_content(
 
 
 @router.put("/{content_id}", response_model=ContentRetrieve)
+@observe()
 async def edit_content(
     content_id: int,
     content: ContentCreate,

--- a/core_backend/app/dashboard/routers.py
+++ b/core_backend/app/dashboard/routers.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import random
 from datetime import date, datetime, timedelta, timezone
 from typing import Annotated, Literal, Optional
 
@@ -16,6 +17,7 @@ from fastapi import (
     Request,
     status,
 )
+from langfuse.decorators import langfuse_context, observe
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import get_current_workspace_name
@@ -119,6 +121,7 @@ async def retrieve_content_details(
     "/performance/{timeframe}/{content_id}/ai-summary",
     response_model=AIFeedbackSummary,
 )
+@observe()
 async def retrieve_content_ai_summary(
     content_id: int,
     timeframe: DashboardTimeFilter,
@@ -168,6 +171,14 @@ async def retrieve_content_ai_summary(
         max_feedback_records=int(MAX_FEEDBACK_RECORDS_FOR_AI_SUMMARY),
         start_date=start_dt,
         workspace_id=workspace_db.workspace_id,
+    )
+
+    langfuse_context.update_current_trace(
+        name="content_feedback_summary",
+        session_id=create_session_id(
+            f"content_{content_id}_feedback", start_dt, end_dt
+        ),
+        metadata={"content_id": content_id, "workspace_id": workspace_db.workspace_id},
     )
 
     return AIFeedbackSummary(ai_summary=ai_summary)
@@ -512,6 +523,7 @@ def get_freq_start_end_date(
             raise ValueError(f"Invalid time frequency: {timeframe}")
 
 
+@observe()
 async def refresh_insights(
     *,
     end_date: date,
@@ -571,6 +583,12 @@ async def refresh_insights(
                 content_data=content_data,
                 query_data=time_period_queries,
                 workspace_id=workspace_db.workspace_id,
+            )
+
+            langfuse_context.update_current_trace(
+                name="topic_modeling",
+                session_id=create_session_id("topic_modeling", start_date, end_date),
+                metadata={"workspace_id": workspace_db.workspace_id},
             )
 
             step = "Write to Redis"
@@ -704,3 +722,14 @@ async def retrieve_performance(
         workspace_id=workspace_id,
     )
     return DashboardPerformance(content_time_series=content_time_series)
+
+
+def create_session_id(
+    prefix: str, start_dt: date | datetime, end_dt: date | datetime
+) -> str:
+    return (
+        prefix
+        + "-"
+        + f"{start_dt:%Y%m%d_%H%M%S}-{end_dt:%Y%m%d_%H%M%S}-"
+        + f"{random.randint(0, 1000):04}"
+    )

--- a/core_backend/app/dashboard/routers.py
+++ b/core_backend/app/dashboard/routers.py
@@ -17,7 +17,7 @@ from fastapi import (
     Request,
     status,
 )
-from langfuse.decorators import langfuse_context, observe
+from langfuse.decorators import langfuse_context, observe  # type: ignore
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import get_current_workspace_name

--- a/core_backend/app/llm_call/dashboard.py
+++ b/core_backend/app/llm_call/dashboard.py
@@ -4,7 +4,7 @@ from bertopic import BERTopic
 
 from ..config import LITELLM_MODEL_DASHBOARD_SUMMARY, LITELLM_MODEL_TOPIC_MODEL
 from ..dashboard.config import DISABLE_DASHBOARD_LLM
-from ..utils import create_langfuse_metadata, setup_logger
+from ..utils import setup_logger
 from .llm_prompts import TopicModelLabelling, get_feedback_summary_prompt
 from .utils import _ask_llm_async
 
@@ -32,17 +32,12 @@ async def generate_ai_summary(
     str
         The AI summary.
     """
-
-    metadata = create_langfuse_metadata(
-        feature_name="dashboard", workspace_id=workspace_id
-    )
     ai_feedback_summary_prompt = get_feedback_summary_prompt(
         content=content_text, content_title=content_title
     )
 
     ai_summary = await _ask_llm_async(
         litellm_model=LITELLM_MODEL_DASHBOARD_SUMMARY,
-        metadata=metadata,
         system_message=ai_feedback_summary_prompt,
         user_message="\n".join(feedback),
     )
@@ -108,9 +103,6 @@ Hint: To enable full AI summaries please set the DASHBOARD_LLM environment varia
         return {"topic_title": topic_title, "topic_summary": topic_summary}
 
     # If LLM is enabled, proceed with LLM-based label generation.
-    metadata = create_langfuse_metadata(
-        feature_name="topic-modeling", workspace_id=workspace_id
-    )
     topic_model_labelling = TopicModelLabelling(context=context)
 
     combined_texts = "\n".join(
@@ -120,7 +112,6 @@ Hint: To enable full AI summaries please set the DASHBOARD_LLM environment varia
     topic_json = await _ask_llm_async(
         json_=True,
         litellm_model=LITELLM_MODEL_TOPIC_MODEL,
-        metadata=metadata,
         system_message=topic_model_labelling.get_prompt(),
         user_message=combined_texts,
     )

--- a/core_backend/app/llm_call/process_input.py
+++ b/core_backend/app/llm_call/process_input.py
@@ -15,7 +15,7 @@ from ..question_answer.schemas import (
     QueryResponse,
     QueryResponseError,
 )
-from ..utils import create_langfuse_metadata, setup_logger
+from ..utils import setup_logger
 from .llm_prompts import (
     PARAPHRASE_FAILED_MESSAGE,
     PARAPHRASE_PROMPT,
@@ -69,11 +69,8 @@ def identify_language__before(func: Callable) -> Callable:
             The appropriate response object.
         """
 
-        metadata = create_langfuse_metadata(
-            query_id=response.query_id, workspace_id=query_refined.workspace_id
-        )
         query_refined, response = await _identify_language(
-            metadata=metadata, query_refined=query_refined, response=response
+            query_refined=query_refined, response=response
         )
         response = await func(query_refined, response, *args, **kwargs)
         return response
@@ -227,12 +224,8 @@ def translate_question__before(func: Callable) -> Callable:
             The appropriate response object.
         """
 
-        metadata = create_langfuse_metadata(
-            query_id=response.query_id, workspace_id=query_refined.workspace_id
-        )
-
         query_refined, response = await _translate_question(
-            metadata=metadata, query_refined=query_refined, response=response
+            query_refined=query_refined, response=response
         )
         response = await func(query_refined, response, *args, **kwargs)
 
@@ -354,12 +347,8 @@ def classify_safety__before(func: Callable) -> Callable:
             The appropriate response object.
         """
 
-        metadata = create_langfuse_metadata(
-            query_id=response.query_id, workspace_id=query_refined.workspace_id
-        )
-
         query_refined, response = await _classify_safety(
-            metadata=metadata, query_refined=query_refined, response=response
+            query_refined=query_refined, response=response
         )
         response = await func(query_refined, response, *args, **kwargs)
         return response
@@ -471,13 +460,9 @@ def paraphrase_question__before(func: Callable) -> Callable:
             The appropriate response object.
         """
 
-        metadata = create_langfuse_metadata(
-            query_id=response.query_id, workspace_id=query_refined.workspace_id
-        )
-
         if not query_refined.chat_query_params:
             query_refined, response = await _paraphrase_question(
-                metadata=metadata, query_refined=query_refined, response=response
+                query_refined=query_refined, response=response
             )
         response = await func(query_refined, response, *args, **kwargs)
 

--- a/core_backend/app/llm_call/process_output.py
+++ b/core_backend/app/llm_call/process_output.py
@@ -179,7 +179,7 @@ def check_align_score__after(func: Callable) -> Callable:
             return response
 
         metadata = create_langfuse_metadata(
-            query_id=response.query_id, workspace_id=query_refined.workspace_id
+            workspace_id=query_refined.workspace_id, session_id=query_refined.session_id
         )
         response = await _check_align_score(metadata=metadata, response=response)
         return response

--- a/core_backend/app/llm_call/utils.py
+++ b/core_backend/app/llm_call/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import redis.asyncio as aioredis
 import requests  # type: ignore
-from langfuse.decorators import langfuse_context
+from langfuse.decorators import langfuse_context  # type: ignore
 from litellm import acompletion, token_counter
 
 from ..config import (

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -10,7 +10,7 @@ import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, status
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
-from langfuse.decorators import langfuse_context, observe
+from langfuse.decorators import langfuse_context, observe  # type: ignore
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -10,6 +10,7 @@ import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, status
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
+from langfuse.decorators import langfuse_context, observe
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,7 +48,6 @@ from ..llm_call.utils import (
 from ..schemas import QuerySearchResult
 from ..users.models import WorkspaceDB
 from ..utils import (
-    create_langfuse_metadata,
     generate_random_filename,
     get_random_int32,
     setup_logger,
@@ -101,6 +101,7 @@ router = APIRouter(
         }
     },
 )
+@observe()
 async def chat(
     user_query: QueryBase,
     request: Request,
@@ -148,6 +149,7 @@ async def chat(
             asession=asession,
             workspace_db=workspace_db,
         )
+        langfuse_context.update_current_trace(name="chat")
         return response
     except LLMCallException:
         return JSONResponse(
@@ -170,6 +172,7 @@ async def chat(
         }
     },
 )
+@observe()
 async def search(
     user_query: QueryBase,
     request: Request,
@@ -225,6 +228,12 @@ async def search(
             response = await get_generation_response(
                 query_refined=user_query_refined_template, response=response
             )
+
+        langfuse_context.update_current_trace(
+            name="search",
+            session_id=user_query_refined_template.session_id,
+            metadata={"query_id": response.query_id, "workspace_id": workspace_id},
+        )
 
         await save_query_response_to_db(
             asession=asession,
@@ -282,6 +291,7 @@ async def search(
         },
     },
 )
+@observe()
 async def voice_search(
     file_url: str,
     request: Request,
@@ -374,6 +384,12 @@ async def voice_search(
             response = await get_generation_response(
                 query_refined=user_query_refined_template, response=response
             )
+
+        langfuse_context.update_current_trace(
+            name="voice-search",
+            session_id=user_query_refined_template.session_id,
+            metadata={"query_id": response.query_id, "workspace_id": workspace_id},
+        )
 
         await save_query_response_to_db(
             asession=asession,
@@ -479,10 +495,6 @@ async def get_search_response(
 
     # No checks for errors: always do the embeddings search even if some guardrails
     # have failed.
-    metadata = create_langfuse_metadata(
-        query_id=response.query_id, workspace_id=workspace_id
-    )
-
     if USE_CROSS_ENCODER == "True" and (n_to_crossencoder < n_similar):
         raise ValueError(
             f"`n_to_crossencoder`({n_to_crossencoder}) must be less than or equal to "
@@ -492,7 +504,6 @@ async def get_search_response(
     search_results = await get_similar_content_async(
         asession=asession,
         exclude_archived=exclude_archived,
-        metadata=metadata,
         n_similar=n_to_crossencoder if USE_CROSS_ENCODER == "True" else n_similar,
         question=query_refined.query_text,  # Use latest transformed version of the text
         workspace_id=workspace_id,
@@ -583,12 +594,9 @@ async def get_generation_response(
     if not query_refined.generate_llm_response:
         return response
 
-    metadata = create_langfuse_metadata(
-        query_id=response.query_id, workspace_id=query_refined.workspace_id
-    )
-
     response, chat_history = await generate_llm_query_response(
-        query_refined=query_refined, response=response, metadata=metadata
+        query_refined=query_refined,
+        response=response,
     )
     if query_refined.chat_query_params and chat_history:
         chat_cache_key = query_refined.chat_query_params["chat_cache_key"]

--- a/core_backend/app/question_answer/schemas.py
+++ b/core_backend/app/question_answer/schemas.py
@@ -28,15 +28,15 @@ class ErrorType(str, Enum):
 class QueryBase(BaseModel):
     """Pydantic model for question answering query."""
 
-    chat_query_params: Optional[dict[str, Any]] = Field(
-        default=None, description="Query parameters for chat"
+    chat_query_params: SkipJsonSchema[Optional[dict[str, Any]]] = Field(
+        default=None, description="Query parameters for chat", exclude=True
     )
     generate_llm_response: bool = Field(False)
     query_metadata: dict = Field(
         default_factory=dict, examples=[{"some_key": "some_value"}]
     )
     query_text: str = Field(..., examples=["What is AAQ?"])
-    session_id: SkipJsonSchema[int | None] = Field(default=None, exclude=True)
+    session_id: int | None = Field(default=None)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/core_backend/app/urgency_detection/routers.py
+++ b/core_backend/app/urgency_detection/routers.py
@@ -3,7 +3,7 @@
 from typing import Callable
 
 from fastapi import APIRouter, Depends
-from langfuse.decorators import langfuse_context, observe
+from langfuse.decorators import langfuse_context, observe  # type: ignore
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import authenticate_key, rate_limiter

--- a/core_backend/app/urgency_rules/routers.py
+++ b/core_backend/app/urgency_rules/routers.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 from fastapi.exceptions import HTTPException
-from langfuse.decorators import langfuse_context, observe
+from langfuse.decorators import langfuse_context, observe  # type: ignore
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import get_current_user, get_current_workspace_name

--- a/core_backend/app/urgency_rules/routers.py
+++ b/core_backend/app/urgency_rules/routers.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 from fastapi.exceptions import HTTPException
+from langfuse.decorators import langfuse_context, observe
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import get_current_user, get_current_workspace_name
@@ -32,6 +33,7 @@ logger = setup_logger(name=__name__)
 
 
 @router.post("/", response_model=UrgencyRuleRetrieve)
+@observe()
 async def create_urgency_rule(
     urgency_rule: UrgencyRuleCreate,
     calling_user_db: Annotated[UserDB, Depends(get_current_user)],
@@ -84,6 +86,13 @@ async def create_urgency_rule(
             asession=asession,
             urgency_rule=urgency_rule,
             workspace_id=workspace_db.workspace_id,
+        )
+        langfuse_context.update_current_trace(
+            name="create_urgency_rule",
+            metadata={
+                "urgency_rule_id": urgency_rule_db.urgency_rule_id,
+                "workspace_id": workspace_db.workspace_id,
+            },
         )
     except EmbeddingCallException as e:
         raise HTTPException(
@@ -200,6 +209,7 @@ async def delete_urgency_rule(
 
 
 @router.put("/{urgency_rule_id}", response_model=UrgencyRuleRetrieve)
+@observe()
 async def update_urgency_rule(
     urgency_rule_id: int,
     urgency_rule: UrgencyRuleCreate,
@@ -267,6 +277,13 @@ async def update_urgency_rule(
             urgency_rule=urgency_rule,
             urgency_rule_id=urgency_rule_id,
             workspace_id=workspace_id,
+        )
+        langfuse_context.update_current_trace(
+            name="update_urgency_rule",
+            metadata={
+                "urgency_rule_id": urgency_rule_db.urgency_rule_id,
+                "workspace_id": workspace_db.workspace_id,
+            },
         )
     except EmbeddingCallException as e:
         raise HTTPException(

--- a/core_backend/app/utils.py
+++ b/core_backend/app/utils.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 import aiohttp
 import litellm
 from google.cloud import storage  # type: ignore
-from langfuse.decorators import langfuse_context
+from langfuse.decorators import langfuse_context  # type: ignore
 from litellm import aembedding
 from redis import asyncio as aioredis
 


### PR DESCRIPTION
Reviewer:
Estimate: 20 minutes

---

## Ticket

Fixes:

## Description

### Goal

1. Ensure a chat session is tracked on langfuse using `session_id`
2. Ensure all observations (LLM calls) for a single query are encapsulated in a single trace

https://www.loom.com/share/3691098530224f948771a5b73fccbe6d?sid=fb686cdc-4c83-49b1-8f56-0686414af4de

### Changes

1. Uses Langfuse's `@observe` decorator for easier management


### Future Tasks (optional)

## How has this been tested?

1. Set up langfuse env vars in .core_backend.env (Either use your own langfuse API key or use our team's -- should be saved in NordPass)
2. Test the following functionalities
  1. Test Chat  -- chat for multiple turns
  2. Test Search
  3. Dashboard - Content Feedback - click on a content to generate content feedback summary
  4. Dashboard - Topic Modelling - Run topic modelling
  5. Urgency Detection test
3. Go to langfuse dashboard to view the traces have been created as expected. Multiturn chat should belong to the same session.

## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
