### PR TITLE
Update docker-compose-dev.yml to avoid running npm i locally

### DIFF
--- a/deployment/docker-compose/docker-compose-dev.yml
+++ b/deployment/docker-compose/docker-compose-dev.yml
@@ -32,6 +32,7 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - ../../admin_app:/app
+      - /app/node_modules
     depends_on:
       - core_backend
     restart: always


### PR DESCRIPTION
Reviewer: @suzinyou
Estimate: 5 mins

## Test by
- Removing your node_modules
- Running make run-docker-compose-dev
- The should work even though you don't have any local node modules