### PR TITLE
Remove date type for time-based query parameters.

### DIFF
--- a/core_backend/app/data_api/routers.py
+++ b/core_backend/app/data_api/routers.py
@@ -1,6 +1,6 @@
 """This module contains FastAPI routers for data API endpoints."""
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -142,21 +142,15 @@ async def get_urgency_rules(
 @router.get("/queries", response_model=list[QueryExtract])
 async def get_queries(
     start_date: Annotated[
-        datetime | date,
+        datetime,
         Query(
-            description=(
-                "Can be date or UTC datetime. "
-                "Example: `2021-01-01` or `2021-01-01T00:00:00`"
-            ),
+            description=("A UTC datetime." "Example: `2021-01-01T00:00:00`"),
         ),
     ],
     end_date: Annotated[
-        datetime | date,
+        datetime,
         Query(
-            description=(
-                "Can be date or UTC datetime. "
-                "Example: `2021-01-01` or `2021-01-01T00:00:00`"
-            ),
+            description=("A UTC datetime." "Example: `2021-01-01T00:00:00`"),
         ),
     ],
     workspace_db: Annotated[WorkspaceDB, Depends(authenticate_key)],
@@ -164,9 +158,6 @@ async def get_queries(
 ) -> list[QueryExtract]:
     """Get all queries including child records for a workspace between a start and end
     date.
-
-    Note that the `start_date` and `end_date` can be provided as a date or `datetime`
-    object.
 
     Parameters
     ----------
@@ -184,11 +175,6 @@ async def get_queries(
     list[QueryExtract]
         A list of QueryExtract objects containing all queries for the user.
     """
-
-    if isinstance(start_date, date):
-        start_date = datetime.combine(start_date, datetime.min.time())
-    if isinstance(end_date, date):
-        end_date = datetime.combine(end_date, datetime.max.time())
 
     start_date = start_date.replace(tzinfo=timezone.utc)
     end_date = end_date.replace(tzinfo=timezone.utc)
@@ -214,21 +200,15 @@ async def get_queries(
 @router.get("/urgency-queries", response_model=list[UrgencyQueryExtract])
 async def get_urgency_queries(
     start_date: Annotated[
-        datetime | date,
+        datetime,
         Query(
-            description=(
-                "Can be date or UTC datetime. "
-                "Example: `2021-01-01` or `2021-01-01T00:00:00`"
-            ),
+            description=("A UTC datetime." "Example: `2021-01-01T00:00:00`"),
         ),
     ],
     end_date: Annotated[
-        datetime | date,
+        datetime,
         Query(
-            description=(
-                "Can be date or UTC datetime. "
-                "Example: `2021-01-01` or `2021-01-01T00:00:00`"
-            ),
+            description=("A UTC datetime." "Example: `2021-01-01T00:00:00`"),
         ),
     ],
     workspace_db: Annotated[WorkspaceDB, Depends(authenticate_key)],
@@ -236,9 +216,6 @@ async def get_urgency_queries(
 ) -> list[UrgencyQueryExtract]:
     """Get all urgency queries including child records for a workspace between a start
     and end date.
-
-    Note that the `start_date` and `end_date` can be provided as a date or `datetime`
-    object.
 
     Parameters
     ----------
@@ -257,11 +234,6 @@ async def get_urgency_queries(
         A list of `UrgencyQueryExtract` objects containing all urgent queries for the
         workspace.
     """
-
-    if isinstance(start_date, date):
-        start_date = datetime.combine(start_date, datetime.min.time())
-    if isinstance(end_date, date):
-        end_date = datetime.combine(end_date, datetime.max.time())
 
     start_date = start_date.replace(tzinfo=timezone.utc)
     end_date = end_date.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate:

---

## Ticket

Fixes: Datetime casting bug

## Description

Querying time filterable endpoints such as queries and urgency-queries with intra-day date-time parameters result in query results for the full day being returned. This is as a result of behaviour described [here](https://stackoverflow.com/questions/69772211/determine-if-datetime-object-is-date-or-datetime#:~:text=If%20you%20look%20at%20the,dtDate%20is%20a%20datetime%20object).

When passing datetime objects, the instance check will always pass since datetime is a date subclass. This will then set the date parameters to the start and end of the days respectively.

Local tests are complaining about duplicated CLI args in `core_backend/validation/urgency_detection/conftest.py`. I get this even when running pytest -vv in main, so I'm not sure what I'm missing there. I also attempted a `mkdocs build` to account for the updated docstrings but I don't notice any changes as a result.

### Goal

To allow intraday datetimes.

### Changes

These changes involve removing date support and relying solely on datetime arguments for these endpoints. This is standard practice.

### Future Tasks (optional)

## How has this been tested?

The tests have been run and confirmed to pass.

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests [_local test setup failing as a result of cli args in `core_backend/validation/urgency_detection/conftest.py`_]
- [ ] I have updated the scripts in `scripts/` [_no /scripts directory_]
- [ ] I have updated affected documentation [_mkdocs build does not output any changes_]
