### PR TITLE
Avoid POSIX shells, use active Python env

### DIFF
--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -26,8 +26,8 @@ setup-test-containers: setup-test-db setup-redis-test
 teardown-test-containers: teardown-test-db teardown-redis-test
 
 setup-test-db:
-	# -@docker stop testdb
-	# -@docker rm testdb
+	-@docker stop testdb
+	-@docker rm testdb
 	@docker system prune -f
 	@sleep 2
 	@set -a && source ./tests/api/test.env && set +a && \
@@ -42,8 +42,8 @@ setup-test-db:
 
 # Use port 6381 since port 6379 is used for dev and 6380 for docker-compose
 setup-redis-test:
-	# -@docker stop redis-test
-	# -@docker rm redis-test
+	-@docker stop redis-test
+	-@docker rm redis-test
 	@docker system prune -f
 	@sleep 2
 	@docker run --name redis-test \

--- a/core_backend/Makefile
+++ b/core_backend/Makefile
@@ -1,5 +1,8 @@
 #!make
 
+SHELL := /bin/bash
+PYTHON := $(shell which python)
+
 .PHONY : tests
 
 # Main test target
@@ -11,20 +14,20 @@ tests-alembic: setup-test-containers run-tests-alembic teardown-test-containers
 # tests should be run first.
 run-tests:
 	@set -a && source ./tests/api/test.env && set +a && \
-	python -m pytest -rPQ -m "not rails and not alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov-append --cov=. --ignore-glob="tests/api/step_definitions/*" tests && \
-	python -m pytest -rPQ -m "not rails and not alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov-append --cov=. tests/api/step_definitions
+	$(PYTHON) -m pytest -rPQ -m "not rails and not alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov-append --cov=. --ignore-glob="tests/api/step_definitions/*" tests && \
+	$(PYTHON) -m pytest -rPQ -m "not rails and not alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov-append --cov=. tests/api/step_definitions
 
 run-tests-alembic:
 	@set -a && source ./tests/api/test.env && set +a && \
-	python -m pytest -rPQ -m "not rails and alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov=. tests/api/test_alembic_migrations.py
+	$(PYTHON) -m pytest -rPQ -m "not rails and alembic" --cov-report term-missing --cov-config=../pyproject.toml --cov=. tests/api/test_alembic_migrations.py
 
 ## Helper targets
 setup-test-containers: setup-test-db setup-redis-test
 teardown-test-containers: teardown-test-db teardown-redis-test
 
 setup-test-db:
-	-@docker stop testdb
-	-@docker rm testdb
+	# -@docker stop testdb
+	# -@docker rm testdb
 	@docker system prune -f
 	@sleep 2
 	@set -a && source ./tests/api/test.env && set +a && \
@@ -35,12 +38,12 @@ setup-test-db:
 		-e POSTGRES_DB \
 		-d pgvector/pgvector:pg16
 	@set -a && source ./tests/api/test.env && set +a && \
-	python -m alembic upgrade head
+	$(PYTHON) -m alembic upgrade head
 
 # Use port 6381 since port 6379 is used for dev and 6380 for docker-compose
 setup-redis-test:
-	-@docker stop redis-test
-	-@docker rm redis-test
+	# -@docker stop redis-test
+	# -@docker rm redis-test
 	@docker system prune -f
 	@sleep 2
 	@docker run --name redis-test \


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate:

---

## Ticket

Fixes: /bin/sh executions of make, lack of support for custom Python envs.

## Description

When running make on certain systems, the shell defaults to /bin/sh which enforces POSIX compliance. This is a problem for commands like `source` which is a /bin/bash builtin. Similarly, when executing the make recipes, we use the default `/usr/bin/` executable when something like `.venv/bin/python` might be preferred.

### Goal

The suggestion is to default to /bin/bash and use the user's active Python env instead.

### Changes

This changes the core-backend's Makefile to default to /bin/bash and currently active Python env.

## How has this been tested?

Manually on Ubuntu 22 WSL

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
